### PR TITLE
fix(s): spelling mistakes, and external link handling on login page

### DIFF
--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -147,10 +147,10 @@
           <a href="https://twitter.com/haybytes" class="tooltip" data-tip="Follow The Developer" target="_blank">
             <Icon name="mdi-twitter" class="h-8 w-8" />
           </a>
-          <a href="https://discord.gg/tuncmNrE4z" class="tooltip" data-tip="Join The Discord">
+          <a href="https://discord.gg/tuncmNrE4z" class="tooltip" data-tip="Join The Discord" target="_blank">
             <Icon name="mdi-discord" class="h-8 w-8" />
           </a>
-          <a href="https://hay-kot.github.io/homebox/" class="tooltip" data-tip="Read The Docs">
+          <a href="https://hay-kot.github.io/homebox/" class="tooltip" data-tip="Read The Docs" target="_blank">
             <Icon name="mdi-folder" class="h-8 w-8" />
           </a>
         </div>

--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -76,7 +76,7 @@
         text: item.value?.serialNumber,
       },
       {
-        name: "Mode Number",
+        name: "Model Number",
         text: item.value?.modelNumber,
       },
       {

--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -75,7 +75,7 @@
       </template>
       <div class="px-4 pb-4">
         <FormMultiselect v-model="selectedLabels" label="Labels" :items="labels ?? []" />
-        <FormMultiselect v-model="selectedLocations" label="Labels" :items="locations ?? []" />
+        <FormMultiselect v-model="selectedLocations" label="Locations" :items="locations ?? []" />
       </div>
     </BaseCard>
     <section class="mt-10">


### PR DESCRIPTION
## What type of PR is this?

- bug


## What this PR does / why we need it:

homebox\frontend\pages\item\[id]\index.vue
- Resolved spelling error for **Model Number**
- Fixes #64 

homebox\frontend\pages\index.vue
- Updated Discord and Docs links to open in new tabs/windows, following the behaviour of the GitHub and Twitter links
- Fixes #66 

homebox\frontend\pages\items.vue
- Resolved spelling error for second occurrence of **Labels**, changing it to **Locations**
- Fixes #67

## Which issue(s) this PR fixes:

Fixes #64 
Fixes #66 
Fixed #67

## Release Notes

```

- Resolved spelling error for Model Number on item page
- Updated Discord and Docs links to open in new tabs/windows, following the behaviour of the GitHub and Twitter links on the login page
- Resolved spelling error for second occurrence of Labels in the filter section on the items page, changing it to Locations

```