### PR TITLE
fix: conditionally filter parent locations

### DIFF
--- a/backend/app/api/handlers/v1/query_params.go
+++ b/backend/app/api/handlers/v1/query_params.go
@@ -1,0 +1,36 @@
+package v1
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+func queryUUIDList(params url.Values, key string) []uuid.UUID {
+	var ids []uuid.UUID
+	for _, id := range params[key] {
+		uid, err := uuid.Parse(id)
+		if err != nil {
+			continue
+		}
+		ids = append(ids, uid)
+	}
+	return ids
+}
+
+func queryIntOrNegativeOne(s string) int {
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return -1
+	}
+	return i
+}
+
+func queryBool(s string) bool {
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return false
+	}
+	return b
+}

--- a/backend/app/api/handlers/v1/v1_ctrl_items.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items.go
@@ -3,10 +3,7 @@ package v1
 import (
 	"encoding/csv"
 	"net/http"
-	"net/url"
-	"strconv"
 
-	"github.com/google/uuid"
 	"github.com/hay-kot/homebox/backend/internal/core/services"
 	"github.com/hay-kot/homebox/backend/internal/data/repo"
 	"github.com/hay-kot/homebox/backend/internal/sys/validate"
@@ -27,44 +24,17 @@ import (
 // @Router   /v1/items [GET]
 // @Security Bearer
 func (ctrl *V1Controller) HandleItemsGetAll() server.HandlerFunc {
-	uuidList := func(params url.Values, key string) []uuid.UUID {
-		var ids []uuid.UUID
-		for _, id := range params[key] {
-			uid, err := uuid.Parse(id)
-			if err != nil {
-				continue
-			}
-			ids = append(ids, uid)
-		}
-		return ids
-	}
-
-	intOrNegativeOne := func(s string) int {
-		i, err := strconv.Atoi(s)
-		if err != nil {
-			return -1
-		}
-		return i
-	}
-
-	getBool := func(s string) bool {
-		b, err := strconv.ParseBool(s)
-		if err != nil {
-			return false
-		}
-		return b
-	}
 
 	extractQuery := func(r *http.Request) repo.ItemQuery {
 		params := r.URL.Query()
 
 		return repo.ItemQuery{
-			Page:            intOrNegativeOne(params.Get("page")),
-			PageSize:        intOrNegativeOne(params.Get("perPage")),
+			Page:            queryIntOrNegativeOne(params.Get("page")),
+			PageSize:        queryIntOrNegativeOne(params.Get("perPage")),
 			Search:          params.Get("q"),
-			LocationIDs:     uuidList(params, "locations"),
-			LabelIDs:        uuidList(params, "labels"),
-			IncludeArchived: getBool(params.Get("includeArchived")),
+			LocationIDs:     queryUUIDList(params, "locations"),
+			LabelIDs:        queryUUIDList(params, "labels"),
+			IncludeArchived: queryBool(params.Get("includeArchived")),
 		}
 	}
 

--- a/backend/app/api/handlers/v1/v1_ctrl_locations.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_locations.go
@@ -15,13 +15,21 @@ import (
 // @Summary  Get All Locations
 // @Tags     Locations
 // @Produce  json
+// @Param    filterChildren query bool false "Filter locations with parents"
 // @Success  200 {object} server.Results{items=[]repo.LocationOutCount}
 // @Router   /v1/locations [GET]
 // @Security Bearer
 func (ctrl *V1Controller) HandleLocationGetAll() server.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		user := services.UseUserCtx(r.Context())
-		locations, err := ctrl.repo.Locations.GetAll(r.Context(), user.GroupID)
+
+		q := r.URL.Query()
+
+		filter := repo.LocationQuery{
+			FilterChildren: queryBool(q.Get("filterChildren")),
+		}
+
+		locations, err := ctrl.repo.Locations.GetAll(r.Context(), user.GroupID, filter)
 		if err != nil {
 			log.Err(err).Msg("failed to get locations")
 			return validate.NewRequestError(err, http.StatusInternalServerError)

--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -756,6 +756,14 @@ const docTemplate = `{
                     "Locations"
                 ],
                 "summary": "Get All Locations",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Filter locations with parents",
+                        "name": "filterChildren",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -748,6 +748,14 @@
                     "Locations"
                 ],
                 "summary": "Get All Locations",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Filter locations with parents",
+                        "name": "filterChildren",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -960,6 +960,11 @@ paths:
       - Labels
   /v1/locations:
     get:
+      parameters:
+      - description: Filter locations with parents
+        in: query
+        name: filterChildren
+        type: boolean
       produces:
       - application/json
       responses:

--- a/backend/internal/core/services/service_items_test.go
+++ b/backend/internal/core/services/service_items_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hay-kot/homebox/backend/internal/data/repo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +39,7 @@ func TestItemService_CsvImport(t *testing.T) {
 		dataCsv = append(dataCsv, newCsvRow(item))
 	}
 
-	allLocation, err := tRepos.Locations.GetAll(context.Background(), tGroup.ID)
+	allLocation, err := tRepos.Locations.GetAll(context.Background(), tGroup.ID, repo.LocationQuery{})
 	assert.NoError(t, err)
 	locNames := []string{}
 	for _, loc := range allLocation {

--- a/backend/internal/data/repo/repo_locations_test.go
+++ b/backend/internal/data/repo/repo_locations_test.go
@@ -43,7 +43,7 @@ func TestLocationRepositoryGetAllWithCount(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	results, err := tRepos.Locations.GetAll(context.Background(), tGroup.ID)
+	results, err := tRepos.Locations.GetAll(context.Background(), tGroup.ID, LocationQuery{})
 	assert.NoError(t, err)
 
 	for _, loc := range results {

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -41,7 +41,7 @@
   const toast = useNotifier();
 
   const locationsStore = useLocationStore();
-  const locations = computed(() => locationsStore.locations);
+  const locations = computed(() => locationsStore.allLocations);
 
   const labelStore = useLabelStore();
   const labels = computed(() => labelStore.labels);

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -32,7 +32,8 @@
   const rmLocationStoreObserver = defineObserver("locationStore", {
     handler: r => {
       if (r.status === 201 || r.url.match(reLocation)) {
-        locationStore.refresh();
+        locationStore.refreshChildren();
+        locationStore.refreshParents();
       }
       console.debug("locationStore handler called by observer");
     },
@@ -43,7 +44,8 @@
     EventTypes.ClearStores,
     () => {
       labelStore.refresh();
-      locationStore.refresh();
+      locationStore.refreshChildren();
+      locationStore.refreshParents();
     },
     "stores"
   );

--- a/frontend/lib/api/classes/locations.ts
+++ b/frontend/lib/api/classes/locations.ts
@@ -2,9 +2,13 @@ import { BaseAPI, route } from "../base";
 import { LocationOutCount, LocationCreate, LocationOut, LocationUpdate } from "../types/data-contracts";
 import { Results } from "../types/non-generated";
 
+export type LocationsQuery = {
+  filterChildren: boolean;
+};
+
 export class LocationsApi extends BaseAPI {
-  getAll() {
-    return this.http.get<Results<LocationOutCount>>({ url: route("/locations") });
+  getAll(q: LocationsQuery = { filterChildren: false }) {
+    return this.http.get<Results<LocationOutCount>>({ url: route("/locations", q) });
   }
 
   create(body: LocationCreate) {

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -16,7 +16,7 @@
   const auth = useAuthStore();
 
   const locationStore = useLocationStore();
-  const locations = computed(() => locationStore.locations);
+  const locations = computed(() => locationStore.parentLocations);
 
   const labelsStore = useLabelStore();
   const labels = computed(() => labelsStore.labels);

--- a/frontend/pages/item/[id]/edit.vue
+++ b/frontend/pages/item/[id]/edit.vue
@@ -18,7 +18,7 @@
   const itemId = computed<string>(() => route.params.id as string);
 
   const locationStore = useLocationStore();
-  const locations = computed(() => locationStore.locations);
+  const locations = computed(() => locationStore.allLocations);
 
   const labelStore = useLabelStore();
   const labels = computed(() => labelStore.labels);

--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -82,7 +82,7 @@
   });
 
   const locationsStore = useLocationStore();
-  const locations = computed(() => locationsStore.locations);
+  const locations = computed(() => locationsStore.allLocations);
 
   const labelStore = useLabelStore();
   const labels = computed(() => labelStore.labels);

--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -117,7 +117,7 @@
   }
 
   const locationStore = useLocationStore();
-  const locations = computed(() => locationStore.locations);
+  const locations = computed(() => locationStore.allLocations);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const parent = ref<LocationSummary | any>({});

--- a/frontend/stores/locations.ts
+++ b/frontend/stores/locations.ts
@@ -3,7 +3,8 @@ import { LocationOutCount } from "~~/lib/api/types/data-contracts";
 
 export const useLocationStore = defineStore("locations", {
   state: () => ({
-    allLocations: null as LocationOutCount[] | null,
+    parents: null as LocationOutCount[] | null,
+    Locations: null as LocationOutCount[] | null,
     client: useUserApi(),
   }),
   getters: {
@@ -12,21 +13,36 @@ export const useLocationStore = defineStore("locations", {
      * synched with the server by intercepting the API calls and updating on the
      * response
      */
-    locations(state): LocationOutCount[] {
-      if (state.allLocations === null) {
-        Promise.resolve(this.refresh());
+    parentLocations(state): LocationOutCount[] {
+      if (state.parents === null) {
+        Promise.resolve(this.refreshParents());
       }
-      return state.allLocations;
+      return state.parents;
+    },
+    allLocations(state): LocationOutCount[] {
+      if (state.Locations === null) {
+        Promise.resolve(this.refreshChildren());
+      }
+      return state.Locations;
     },
   },
   actions: {
-    async refresh(): Promise<LocationOutCount[]> {
-      const result = await this.client.locations.getAll();
+    async refreshParents(): Promise<LocationOutCount[]> {
+      const result = await this.client.locations.getAll({ filterChildren: true });
       if (result.error) {
         return result;
       }
 
-      this.allLocations = result.data.items;
+      this.parents = result.data.items;
+      return result;
+    },
+    async refreshChildren(): Promise<LocationOutCount[]> {
+      const result = await this.client.locations.getAll({ filterChildren: false });
+      if (result.error) {
+        return result;
+      }
+
+      this.Locations = result.data.items;
       return result;
     },
   },


### PR DESCRIPTION
closes #132 

This is a temporary fix to solve #132, but it does result in over-fetching data on the frontend. It shouldn't have any significant cost for users, so I'm going to add this issue to the backlog and we'll get it resolved when we can. 