### PR TITLE
feat: locations tree viewer

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_locations.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_locations.go
@@ -11,6 +11,27 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// HandleLocationTreeQuery godoc
+// @Summary  Get All Locations
+// @Tags     Locations
+// @Produce  json
+// @Success  200 {object} server.Results{items=[]repo.TreeItem}
+// @Router   /v1/locations/tree [GET]
+// @Security Bearer
+func (ctrl *V1Controller) HandleLocationTreeQuery() server.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		user := services.UseUserCtx(r.Context())
+
+		locTree, err := ctrl.repo.Locations.Tree(r.Context(), user.GroupID)
+		if err != nil {
+			log.Err(err).Msg("failed to get locations tree")
+			return validate.NewRequestError(err, http.StatusInternalServerError)
+		}
+
+		return server.Respond(w, http.StatusOK, server.Results{Items: locTree})
+	}
+}
+
 // HandleLocationGetAll godoc
 // @Summary  Get All Locations
 // @Tags     Locations

--- a/backend/app/api/handlers/v1/v1_ctrl_locations.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_locations.go
@@ -15,6 +15,7 @@ import (
 // @Summary  Get All Locations
 // @Tags     Locations
 // @Produce  json
+// @Param    withItems         query    bool   false "include items in response tree"
 // @Success  200 {object} server.Results{items=[]repo.TreeItem}
 // @Router   /v1/locations/tree [GET]
 // @Security Bearer
@@ -22,7 +23,18 @@ func (ctrl *V1Controller) HandleLocationTreeQuery() server.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		user := services.UseUserCtx(r.Context())
 
-		locTree, err := ctrl.repo.Locations.Tree(r.Context(), user.GroupID)
+		q := r.URL.Query()
+
+		withItems := queryBool(q.Get("withItems"))
+
+		locTree, err := ctrl.repo.Locations.Tree(
+			r.Context(),
+			user.GroupID,
+			repo.TreeQuery{
+				WithItems: withItems,
+			},
+		)
+
 		if err != nil {
 			log.Err(err).Msg("failed to get locations tree")
 			return validate.NewRequestError(err, http.StatusInternalServerError)

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -91,6 +91,7 @@ func (a *app) mountRoutes(repos *repo.AllRepos) {
 
 	a.server.Get(v1Base("/locations"), v1Ctrl.HandleLocationGetAll(), userMW...)
 	a.server.Post(v1Base("/locations"), v1Ctrl.HandleLocationCreate(), userMW...)
+	a.server.Get(v1Base("/locations/tree"), v1Ctrl.HandleLocationTreeQuery(), userMW...)
 	a.server.Get(v1Base("/locations/{id}"), v1Ctrl.HandleLocationGet(), userMW...)
 	a.server.Put(v1Base("/locations/{id}"), v1Ctrl.HandleLocationUpdate(), userMW...)
 	a.server.Delete(v1Base("/locations/{id}"), v1Ctrl.HandleLocationDelete(), userMW...)

--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -1945,6 +1945,10 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "parentId": {
+                    "type": "string",
+                    "x-nullable": true
                 }
             }
         },

--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -1045,6 +1045,45 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/locations/tree": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Locations"
+                ],
+                "summary": "Get All Locations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/server.Results"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "items": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repo.TreeItem"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/v1/locations/{id}": {
             "get": {
                 "security": [
@@ -2113,6 +2152,23 @@ const docTemplate = `{
                 },
                 "total": {
                     "type": "number"
+                }
+            }
+        },
+        "repo.TreeItem": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repo.TreeItem"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -1059,6 +1059,14 @@ const docTemplate = `{
                     "Locations"
                 ],
                 "summary": "Get All Locations",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "include items in response tree",
+                        "name": "withItems",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -2172,6 +2180,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -1937,6 +1937,10 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "parentId": {
+                    "type": "string",
+                    "x-nullable": true
                 }
             }
         },

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -1037,6 +1037,45 @@
                 }
             }
         },
+        "/v1/locations/tree": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Locations"
+                ],
+                "summary": "Get All Locations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/server.Results"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "items": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/repo.TreeItem"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/v1/locations/{id}": {
             "get": {
                 "security": [
@@ -2105,6 +2144,23 @@
                 },
                 "total": {
                     "type": "number"
+                }
+            }
+        },
+        "repo.TreeItem": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repo.TreeItem"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -1051,6 +1051,14 @@
                     "Locations"
                 ],
                 "summary": "Get All Locations",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "include items in response tree",
+                        "name": "withItems",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -2164,6 +2172,9 @@
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -322,6 +322,9 @@ definitions:
         type: string
       name:
         type: string
+      parentId:
+        type: string
+        x-nullable: true
     type: object
   repo.LocationOut:
     properties:

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -459,6 +459,17 @@ definitions:
       total:
         type: number
     type: object
+  repo.TreeItem:
+    properties:
+      children:
+        items:
+          $ref: '#/definitions/repo.TreeItem'
+        type: array
+      id:
+        type: string
+      name:
+        type: string
+    type: object
   repo.UserOut:
     properties:
       email:
@@ -1299,6 +1310,27 @@ paths:
       security:
       - Bearer: []
       summary: updates a location
+      tags:
+      - Locations
+  /v1/locations/tree:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/server.Results'
+            - properties:
+                items:
+                  items:
+                    $ref: '#/definitions/repo.TreeItem'
+                  type: array
+              type: object
+      security:
+      - Bearer: []
+      summary: Get All Locations
       tags:
       - Locations
   /v1/qrcode:

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -472,6 +472,8 @@ definitions:
         type: string
       name:
         type: string
+      type:
+        type: string
     type: object
   repo.UserOut:
     properties:
@@ -1317,6 +1319,11 @@ paths:
       - Locations
   /v1/locations/tree:
     get:
+      parameters:
+      - description: include items in response tree
+        in: query
+        name: withItems
+        type: boolean
       produces:
       - application/json
       responses:

--- a/backend/internal/data/ent/group/group.go
+++ b/backend/internal/data/ent/group/group.go
@@ -131,6 +131,7 @@ const (
 	CurrencyDkk Currency = "dkk"
 	CurrencyInr Currency = "inr"
 	CurrencyRmb Currency = "rmb"
+	CurrencyBgn Currency = "bgn"
 )
 
 func (c Currency) String() string {
@@ -140,7 +141,7 @@ func (c Currency) String() string {
 // CurrencyValidator is a validator for the "currency" field enum values. It is called by the builders before save.
 func CurrencyValidator(c Currency) error {
 	switch c {
-	case CurrencyUsd, CurrencyEur, CurrencyGbp, CurrencyJpy, CurrencyZar, CurrencyAud, CurrencyNok, CurrencySek, CurrencyDkk, CurrencyInr, CurrencyRmb:
+	case CurrencyUsd, CurrencyEur, CurrencyGbp, CurrencyJpy, CurrencyZar, CurrencyAud, CurrencyNok, CurrencySek, CurrencyDkk, CurrencyInr, CurrencyRmb, CurrencyBgn:
 		return nil
 	default:
 		return fmt.Errorf("group: invalid enum value for currency field: %q", c)

--- a/backend/internal/data/ent/migrate/schema.go
+++ b/backend/internal/data/ent/migrate/schema.go
@@ -116,7 +116,7 @@ var (
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "name", Type: field.TypeString, Size: 255},
-		{Name: "currency", Type: field.TypeEnum, Enums: []string{"usd", "eur", "gbp", "jpy", "zar", "aud", "nok", "sek", "dkk", "inr", "rmb"}, Default: "usd"},
+		{Name: "currency", Type: field.TypeEnum, Enums: []string{"usd", "eur", "gbp", "jpy", "zar", "aud", "nok", "sek", "dkk", "inr", "rmb", "bgn"}, Default: "usd"},
 	}
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{

--- a/backend/internal/data/ent/schema/group.go
+++ b/backend/internal/data/ent/schema/group.go
@@ -27,7 +27,7 @@ func (Group) Fields() []ent.Field {
 			NotEmpty(),
 		field.Enum("currency").
 			Default("usd").
-			Values("usd", "eur", "gbp", "jpy", "zar", "aud", "nok", "sek", "dkk", "inr", "rmb"),
+			Values("usd", "eur", "gbp", "jpy", "zar", "aud", "nok", "sek", "dkk", "inr", "rmb", "bgn"),
 	}
 }
 

--- a/backend/internal/data/repo/repo_items.go
+++ b/backend/internal/data/repo/repo_items.go
@@ -356,7 +356,6 @@ func (e *ItemsRepository) QueryByGroup(ctx context.Context, gid uuid.UUID, q Ite
 
 }
 
-
 // QueryByAssetID returns items by asset ID. If the item does not exist, an error is returned.
 func (e *ItemsRepository) QueryByAssetID(ctx context.Context, gid uuid.UUID, assetID AssetID, page int, pageSize int) (PaginationResult[ItemSummary], error) {
 	qb := e.db.Item.Query().Where(
@@ -372,7 +371,7 @@ func (e *ItemsRepository) QueryByAssetID(ctx context.Context, gid uuid.UUID, ass
 		pageSize = -1
 	}
 
-	items, err :=  mapItemsSummaryErr(
+	items, err := mapItemsSummaryErr(
 		qb.Order(ent.Asc(item.FieldName)).
 			WithLabel().
 			WithLocation().

--- a/backend/internal/data/repo/repo_items_test.go
+++ b/backend/internal/data/repo/repo_items_test.go
@@ -36,6 +36,8 @@ func useItems(t *testing.T, len int) []ItemOut {
 		for _, item := range items {
 			_ = tRepos.Items.Delete(context.Background(), item.ID)
 		}
+
+		_ = tRepos.Locations.Delete(context.Background(), location.ID)
 	})
 
 	return items

--- a/backend/internal/data/repo/repo_locations.go
+++ b/backend/internal/data/repo/repo_locations.go
@@ -176,9 +176,7 @@ func (r *LocationRepository) Create(ctx context.Context, GID uuid.UUID, data Loc
 		SetDescription(data.Description).
 		SetGroupID(GID)
 
-	println(data.ParentID.String())
 	if data.ParentID != uuid.Nil {
-		println("SET PARENT")
 		q.SetParentID(data.ParentID)
 	}
 

--- a/backend/internal/data/repo/repo_locations.go
+++ b/backend/internal/data/repo/repo_locations.go
@@ -19,8 +19,9 @@ type LocationRepository struct {
 
 type (
 	LocationCreate struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
+		Name        string    `json:"name"`
+		ParentID    uuid.UUID `json:"parentId" extensions:"x-nullable"`
+		Description string    `json:"description"`
 	}
 
 	LocationUpdate struct {
@@ -170,11 +171,18 @@ func (r *LocationRepository) GetOneByGroup(ctx context.Context, GID, ID uuid.UUI
 }
 
 func (r *LocationRepository) Create(ctx context.Context, GID uuid.UUID, data LocationCreate) (LocationOut, error) {
-	location, err := r.db.Location.Create().
+	q := r.db.Location.Create().
 		SetName(data.Name).
 		SetDescription(data.Description).
-		SetGroupID(GID).
-		Save(ctx)
+		SetGroupID(GID)
+
+	println(data.ParentID.String())
+	if data.ParentID != uuid.Nil {
+		println("SET PARENT")
+		q.SetParentID(data.ParentID)
+	}
+
+	location, err := q.Save(ctx)
 
 	if err != nil {
 		return LocationOut{}, err

--- a/backend/internal/data/repo/repo_locations_test.go
+++ b/backend/internal/data/repo/repo_locations_test.go
@@ -134,7 +134,7 @@ func TestItemRepository_TreeQuery(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	locations, err := tRepos.Locations.Tree(context.Background(), tGroup.ID)
+	locations, err := tRepos.Locations.Tree(context.Background(), tGroup.ID, TreeQuery{WithItems: true})
 
 	assert.NoError(t, err)
 

--- a/backend/internal/data/repo/repo_locations_test.go
+++ b/backend/internal/data/repo/repo_locations_test.go
@@ -138,18 +138,13 @@ func TestItemRepository_TreeQuery(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, 3, len(locations))
+	assert.Equal(t, 2, len(locations))
 
-	for _, loc := range locs {
-		found := false
-
-		for _, l := range locations {
-			if l.ID == loc.ID {
-				found = true
-			}
+	// Check roots
+	for _, loc := range locations {
+		if loc.ID == locs[1].ID {
+			assert.Equal(t, 1, len(loc.Children))
 		}
-
-		assert.True(t, found)
 	}
 }
 

--- a/backend/internal/data/repo/repo_locations_test.go
+++ b/backend/internal/data/repo/repo_locations_test.go
@@ -2,8 +2,11 @@ package repo
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/hay-kot/homebox/backend/internal/data/ent"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,6 +15,30 @@ func locationFactory() LocationCreate {
 		Name:        fk.Str(10),
 		Description: fk.Str(100),
 	}
+}
+
+func useLocations(t *testing.T, len int) []LocationOut {
+	t.Helper()
+
+	out := make([]LocationOut, len)
+
+	for i := 0; i < len; i++ {
+		loc, err := tRepos.Locations.Create(context.Background(), tGroup.ID, locationFactory())
+		assert.NoError(t, err)
+		out[i] = loc
+	}
+
+	t.Cleanup(func() {
+		for _, loc := range out {
+			err := tRepos.Locations.Delete(context.Background(), loc.ID)
+
+			if err != nil {
+				assert.True(t, ent.IsNotFound(err))
+			}
+		}
+	})
+
+	return out
 }
 
 func TestLocationRepository_Get(t *testing.T) {
@@ -29,13 +56,9 @@ func TestLocationRepository_Get(t *testing.T) {
 
 func TestLocationRepositoryGetAllWithCount(t *testing.T) {
 	ctx := context.Background()
-	result, err := tRepos.Locations.Create(ctx, tGroup.ID, LocationCreate{
-		Name:        fk.Str(10),
-		Description: fk.Str(100),
-	})
-	assert.NoError(t, err)
+	result := useLocations(t, 1)[0]
 
-	_, err = tRepos.Items.Create(ctx, tGroup.ID, ItemCreate{
+	_, err := tRepos.Items.Create(ctx, tGroup.ID, ItemCreate{
 		Name:        fk.Str(10),
 		Description: fk.Str(100),
 		LocationID:  result.ID,
@@ -55,8 +78,7 @@ func TestLocationRepositoryGetAllWithCount(t *testing.T) {
 }
 
 func TestLocationRepository_Create(t *testing.T) {
-	loc, err := tRepos.Locations.Create(context.Background(), tGroup.ID, locationFactory())
-	assert.NoError(t, err)
+	loc := useLocations(t, 1)[0]
 
 	// Get by ID
 	foundLoc, err := tRepos.Locations.Get(context.Background(), loc.ID)
@@ -68,8 +90,7 @@ func TestLocationRepository_Create(t *testing.T) {
 }
 
 func TestLocationRepository_Update(t *testing.T) {
-	loc, err := tRepos.Locations.Create(context.Background(), tGroup.ID, locationFactory())
-	assert.NoError(t, err)
+	loc := useLocations(t, 1)[0]
 
 	updateData := LocationUpdate{
 		ID:          loc.ID,
@@ -92,12 +113,159 @@ func TestLocationRepository_Update(t *testing.T) {
 }
 
 func TestLocationRepository_Delete(t *testing.T) {
-	loc, err := tRepos.Locations.Create(context.Background(), tGroup.ID, locationFactory())
-	assert.NoError(t, err)
+	loc := useLocations(t, 1)[0]
 
-	err = tRepos.Locations.Delete(context.Background(), loc.ID)
+	err := tRepos.Locations.Delete(context.Background(), loc.ID)
 	assert.NoError(t, err)
 
 	_, err = tRepos.Locations.Get(context.Background(), loc.ID)
 	assert.Error(t, err)
+}
+
+func TestItemRepository_TreeQuery(t *testing.T) {
+	locs := useLocations(t, 3)
+
+	// Set relations
+	_, err := tRepos.Locations.UpdateOneByGroup(context.Background(), tGroup.ID, locs[0].ID, LocationUpdate{
+		ID:          locs[0].ID,
+		ParentID:    locs[1].ID,
+		Name:        locs[0].Name,
+		Description: locs[0].Description,
+	})
+	assert.NoError(t, err)
+
+	locations, err := tRepos.Locations.Tree(context.Background(), tGroup.ID)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, 3, len(locations))
+
+	for _, loc := range locs {
+		found := false
+
+		for _, l := range locations {
+			if l.ID == loc.ID {
+				found = true
+			}
+		}
+
+		assert.True(t, found)
+	}
+}
+
+func TestConvertLocationsToTree(t *testing.T) {
+	uuid1, uuid2, uuid3, uuid4 := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	testCases := []struct {
+		name      string
+		locations []FlatTreeItem
+		expected  []TreeItem
+	}{
+		{
+			name: "Convert locations to tree",
+			locations: []FlatTreeItem{
+				{
+					ID:       uuid1,
+					Name:     "Root1",
+					ParentID: uuid.Nil,
+					Level:    0,
+				},
+				{
+					ID:       uuid2,
+					Name:     "Child1",
+					ParentID: uuid1,
+					Level:    1,
+				},
+				{
+					ID:       uuid3,
+					Name:     "Child2",
+					ParentID: uuid1,
+					Level:    1,
+				},
+			},
+			expected: []TreeItem{
+				{
+					ID:   uuid1,
+					Name: "Root1",
+					Children: []*TreeItem{
+						{
+							ID:       uuid2,
+							Name:     "Child1",
+							Children: []*TreeItem{},
+						},
+						{
+							ID:       uuid3,
+							Name:     "Child2",
+							Children: []*TreeItem{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Convert locations to tree with deeply nested children",
+			locations: []FlatTreeItem{
+				{
+					ID:       uuid1,
+					Name:     "Root1",
+					ParentID: uuid.Nil,
+					Level:    0,
+				},
+				{
+					ID:       uuid2,
+					Name:     "Child1",
+					ParentID: uuid1,
+					Level:    1,
+				},
+				{
+					ID:       uuid3,
+					Name:     "Child2",
+					ParentID: uuid2,
+					Level:    2,
+				},
+				{
+					ID:       uuid4,
+					Name:     "Child3",
+					ParentID: uuid3,
+					Level:    3,
+				},
+			},
+			expected: []TreeItem{
+				{
+					ID:   uuid1,
+					Name: "Root1",
+					Children: []*TreeItem{
+						{
+							ID:   uuid2,
+							Name: "Child1",
+							Children: []*TreeItem{
+								{
+									ID:   uuid3,
+									Name: "Child2",
+									Children: []*TreeItem{
+										{
+											ID:       uuid4,
+											Name:     "Child3",
+											Children: []*TreeItem{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertLocationsToTree(tc.locations)
+
+			// Compare JSON strings
+			expected, _ := json.Marshal(tc.expected)
+			got, _ := json.Marshal(result)
+			assert.Equal(t, string(expected), string(got))
+		})
+	}
 }

--- a/frontend/components/Form/Autocomplete.vue
+++ b/frontend/components/Form/Autocomplete.vue
@@ -51,7 +51,7 @@
 
   interface Props {
     label: string;
-    modelValue: string | ItemsObject;
+    modelValue: string | ItemsObject | null | undefined;
     items: ItemsObject[] | string[];
     itemText?: keyof ItemsObject;
     itemSearch?: keyof ItemsObject | null;
@@ -129,7 +129,7 @@
     }
   );
 
-  function select(obj: string | ItemsObject) {
+  function select(obj: Props["modelValue"]) {
     if (isStrings(props.items)) {
       if (obj === value.value) {
         value.value = "";

--- a/frontend/components/Item/View/Selectable.vue
+++ b/frontend/components/Item/View/Selectable.vue
@@ -19,7 +19,6 @@
   });
 
   function setViewPreference(view: ViewType) {
-    console.log("setViewPreference", view);
     preferences.value.itemDisplayView = view;
   }
 </script>

--- a/frontend/components/Item/View/Selectable.vue
+++ b/frontend/components/Item/View/Selectable.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+  import { ViewType } from "~~/composables/use-preferences";
+  import { ItemSummary } from "~~/lib/api/types/data-contracts";
+
+  type Props = {
+    view?: ViewType;
+    items: ItemSummary[];
+  };
+
+  const preferences = useViewPreferences();
+
+  const props = defineProps<Props>();
+  const viewSet = computed(() => {
+    return !!props.view;
+  });
+
+  const itemView = computed(() => {
+    return props.view ?? preferences.value.itemDisplayView;
+  });
+
+  function setViewPreference(view: ViewType) {
+    console.log("setViewPreference", view);
+    preferences.value.itemDisplayView = view;
+  }
+</script>
+
+<template>
+  <section>
+    <BaseSectionHeader class="mb-5 flex justify-between items-center">
+      Items
+
+      <template #description>
+        <div v-if="!viewSet" class="dropdown dropdown-hover dropdown-left">
+          <label tabindex="0" class="btn btn-ghost m-1">
+            <Icon name="mdi-dots-vertical" class="h-7 w-7" />
+          </label>
+          <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-32">
+            <li>
+              <button @click="setViewPreference('card')">
+                <Icon name="mdi-card-text-outline" class="h-5 w-5" />
+                Card
+              </button>
+            </li>
+            <li>
+              <button @click="setViewPreference('table')">
+                <Icon name="mdi-table" class="h-5 w-5" />
+                Table
+              </button>
+            </li>
+          </ul>
+        </div>
+      </template>
+    </BaseSectionHeader>
+
+    <template v-if="itemView === 'table'">
+      <ItemViewTable :items="items" />
+    </template>
+    <template v-else>
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        <ItemCard v-for="item in items" :key="item.id" :item="item" />
+      </div>
+    </template>
+  </section>
+</template>
+
+<style scoped></style>

--- a/frontend/components/Item/View/Table.types.ts
+++ b/frontend/components/Item/View/Table.types.ts
@@ -1,0 +1,10 @@
+import { ItemSummary } from "~~/lib/api/types/data-contracts";
+
+export type TableHeader = {
+  text: string;
+  value: keyof ItemSummary;
+  sortable?: boolean;
+  align?: "left" | "center" | "right";
+};
+
+export type TableData = Record<string, any>;

--- a/frontend/components/Item/View/Table.vue
+++ b/frontend/components/Item/View/Table.vue
@@ -1,0 +1,141 @@
+<template>
+  <BaseCard>
+    <table class="table w-full">
+      <thead>
+        <tr class="bg-primary">
+          <th
+            v-for="h in headers"
+            :key="h.value"
+            class="text-no-transform text-sm bg-neutral text-neutral-content"
+            :class="{
+              'text-center': h.align === 'center',
+              'text-right': h.align === 'right',
+              'text-left': h.align === 'left',
+            }"
+          >
+            <template v-if="typeof h === 'string'">{{ h }}</template>
+            <template v-else>{{ h.text }}</template>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(d, i) in data" :key="i" class="hover cursor-pointer" @click="navigateTo(`/item/${d.id}`)">
+          <td
+            v-for="h in headers"
+            :key="`${h.value}-${i}`"
+            class="bg-base-100"
+            :class="{
+              'text-center': h.align === 'center',
+              'text-right': h.align === 'right',
+              'text-left': h.align === 'left',
+            }"
+          >
+            <template v-if="cell(h) === 'cell-name'">
+              <NuxtLink class="hover" :to="`/item/${d.id}`">
+                {{ d.name }}
+              </NuxtLink>
+            </template>
+            <template v-else-if="cell(h) === 'cell-purchasePrice'">
+              <Currency :amount="d.purchasePrice" />
+            </template>
+            <template v-else-if="cell(h) === 'cell-insured'">
+              <Icon v-if="d.insured" name="mdi-check" class="text-green-500 h-5 w-5" />
+              <Icon v-else name="mdi-close" class="text-red-500 h-5 w-5" />
+            </template>
+            <slot v-else :name="cell(h)" v-bind="{ item: d }">
+              {{ extractValue(d, h.value) }}
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="border-t p-3 justify-end flex">
+      <div class="btn-group">
+        <button :disabled="!hasPrev" class="btn btn-sm" @click="prev()">«</button>
+        <button class="btn btn-sm">Page {{ pagination.page }}</button>
+        <button :disabled="!hasNext" class="btn btn-sm" @click="next()">»</button>
+      </div>
+    </div>
+  </BaseCard>
+</template>
+
+<script setup lang="ts">
+  import { TableData, TableHeader } from "./Table.types";
+  import { ItemSummary } from "~~/lib/api/types/data-contracts";
+
+  type Props = {
+    items: ItemSummary[];
+  };
+  const props = defineProps<Props>();
+
+  const sortByProperty = ref<keyof ItemSummary>("name");
+
+  const headers = computed<TableHeader[]>(() => {
+    return [
+      { text: "Name", value: "name" },
+      { text: "Quantity", value: "quantity", align: "center" },
+      { text: "Insured", value: "insured", align: "center" },
+      { text: "Price", value: "purchasePrice" },
+    ] as TableHeader[];
+  });
+
+  const pagination = reactive({
+    sortBy: sortByProperty.value,
+    descending: false,
+    page: 1,
+    rowsPerPage: 10,
+    rowsNumber: 0,
+  });
+
+  const next = () => pagination.page++;
+  const hasNext = computed<boolean>(() => {
+    return pagination.page * pagination.rowsPerPage < props.items.length;
+  });
+
+  const prev = () => pagination.page--;
+  const hasPrev = computed<boolean>(() => {
+    return pagination.page > 1;
+  });
+
+  const data = computed<TableData[]>(() => {
+    // sort by property
+    let data = [...props.items].sort((a, b) => {
+      const aLower = a[sortByProperty.value]?.toLowerCase();
+      const bLower = b[sortByProperty.value]?.toLowerCase();
+
+      if (aLower < bLower) {
+        return -1;
+      }
+      if (aLower > bLower) {
+        return 1;
+      }
+      return 0;
+    });
+
+    // sort descending
+    if (pagination.descending) {
+      data.reverse();
+    }
+
+    // paginate
+    const start = (pagination.page - 1) * pagination.rowsPerPage;
+    const end = start + pagination.rowsPerPage;
+    data = data.slice(start, end);
+    return data;
+  });
+
+  function extractValue(data: TableData, value: string) {
+    const parts = value.split(".");
+    let current = data;
+    for (const part of parts) {
+      current = current[part];
+    }
+    return current;
+  }
+
+  function cell(h: TableHeader) {
+    return `cell-${h.value.replace(".", "_")}`;
+  }
+</script>
+
+<style scoped></style>

--- a/frontend/components/Location/CreateModal.vue
+++ b/frontend/components/Location/CreateModal.vue
@@ -10,24 +10,7 @@
         label="Location Name"
       />
       <FormTextArea v-model="form.description" label="Location Description" />
-      <FormAutocomplete
-        v-model="form.parent"
-        v-model:search="form.search"
-        :items="locations"
-        item-text="display"
-        item-value="id"
-        item-search="name"
-        label="Parent Location"
-      >
-        <template #display="{ item }">
-          <div>
-            <div>
-              {{ item.name }}
-            </div>
-            <div v-if="item.name != item.display" class="text-xs mt-1">{{ item.display }}</div>
-          </div>
-        </template>
-      </FormAutocomplete>
+      <LocationSelector v-model="form.parent" />
       <div class="modal-action">
         <BaseButton type="submit" :loading="loading"> Create </BaseButton>
       </div>
@@ -44,14 +27,11 @@
     },
   });
 
-  const locations = await useFlatLocations();
-
   const modal = useVModel(props, "modelValue");
   const loading = ref(false);
   const focused = ref(false);
   const form = reactive({
     name: "",
-    search: "",
     description: "",
     parent: null as LocationSummary | null,
   });
@@ -66,7 +46,6 @@
   function reset() {
     form.name = "";
     form.description = "";
-    form.search = "";
     form.parent = null;
     focused.value = false;
     modal.value = false;

--- a/frontend/components/Location/CreateModal.vue
+++ b/frontend/components/Location/CreateModal.vue
@@ -12,11 +12,22 @@
       <FormTextArea v-model="form.description" label="Location Description" />
       <FormAutocomplete
         v-model="form.parent"
+        v-model:search="form.search"
         :items="locations"
-        item-text="name"
+        item-text="display"
         item-value="id"
+        item-search="name"
         label="Parent Location"
-      />
+      >
+        <template #display="{ item }">
+          <div>
+            <div>
+              {{ item.name }}
+            </div>
+            <div v-if="item.name != item.display" class="text-xs mt-1">{{ item.display }}</div>
+          </div>
+        </template>
+      </FormAutocomplete>
       <div class="modal-action">
         <BaseButton type="submit" :loading="loading"> Create </BaseButton>
       </div>
@@ -26,7 +37,6 @@
 
 <script setup lang="ts">
   import { LocationSummary } from "~~/lib/api/types/data-contracts";
-  import { useLocationStore } from "~~/stores/locations";
   const props = defineProps({
     modelValue: {
       type: Boolean,
@@ -34,14 +44,14 @@
     },
   });
 
-  const locationStore = useLocationStore();
+  const locations = await useFlatLocations();
 
-  const locations = computed(() => locationStore.allLocations);
   const modal = useVModel(props, "modelValue");
   const loading = ref(false);
   const focused = ref(false);
   const form = reactive({
     name: "",
+    search: "",
     description: "",
     parent: null as LocationSummary | null,
   });
@@ -56,6 +66,7 @@
   function reset() {
     form.name = "";
     form.description = "";
+    form.search = "";
     form.parent = null;
     focused.value = false;
     modal.value = false;

--- a/frontend/components/Location/Selector.vue
+++ b/frontend/components/Location/Selector.vue
@@ -1,0 +1,49 @@
+<template>
+  <FormAutocomplete
+    v-model="value"
+    v-model:search="form.search"
+    :items="locations"
+    item-text="display"
+    item-value="id"
+    item-search="name"
+    label="Parent Location"
+  >
+    <template #display="{ item }">
+      <div>
+        <div>
+          {{ item.name }}
+        </div>
+        <div v-if="item.name != item.display" class="text-xs mt-1">{{ item.display }}</div>
+      </div>
+    </template>
+  </FormAutocomplete>
+</template>
+
+<script lang="ts" setup>
+  import { LocationSummary } from "~~/lib/api/types/data-contracts";
+
+  type Props = {
+    modelValue?: LocationSummary | null;
+  };
+
+  const props = defineProps<Props>();
+
+  const value = useVModel(props, "modelValue");
+
+  const locations = await useFlatLocations();
+
+  const form = ref({
+    parent: null as LocationSummary | null,
+    search: "",
+  });
+
+  // Whenever parent goes from value to null reset search
+  watch(
+    () => value.value,
+    () => {
+      if (!value.value) {
+        form.value.search = "";
+      }
+    }
+  );
+</script>

--- a/frontend/components/Location/Tree/Node.vue
+++ b/frontend/components/Location/Tree/Node.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+  import { useTreeState } from "./tree-state";
+  import { ItemSummary, TreeItem } from "~~/lib/api/types/data-contracts";
+
+  type Props = {
+    type?: "location" | "item";
+    treeId: string;
+    item: TreeItem;
+  };
+  const props = withDefaults(defineProps<Props>(), {
+    type: "location",
+  });
+
+  const link = computed(() => {
+    return props.type === "location" ? `/location/${props.item.id}` : `/item/${props.item.id}`;
+  });
+
+  const hasChildren = computed(() => {
+    return props.item.children.length > 0;
+  });
+
+  const state = useTreeState(props.treeId);
+
+  const openRef = computed({
+    get() {
+      return state.value[nodeHash.value] ?? false;
+    },
+    set(value) {
+      state.value[nodeHash.value] = value;
+    },
+  });
+
+  const nodeHash = computed(() => {
+    // converts a UUID to a short hash
+    return props.item.id.replace(/-/g, "").substring(0, 8);
+  });
+
+  const api = useUserApi();
+
+  const hasFetched = ref(false);
+  const items = ref<ItemSummary[]>([]);
+
+  async function fetchItems() {
+    const { data, error } = await api.items.getAll({
+      locations: [props.item.id],
+    });
+
+    if (error) {
+      return;
+    }
+
+    hasFetched.value = true;
+    items.value = data.items;
+
+    console.log("fetched items", items.value);
+  }
+
+  watch(
+    openRef,
+    async value => {
+      if (value && !hasFetched.value && props.type === "location") {
+        await fetchItems();
+      }
+    },
+    { immediate: true }
+  );
+</script>
+
+<template>
+  <div>
+    <div
+      class="node flex items-center gap-1 rounded p-1"
+      :class="{
+        'cursor-pointer hover:bg-base-200': hasChildren,
+      }"
+      @click="openRef = !openRef"
+    >
+      <div
+        class="p-1/2 rounded mr-1 flex items-center justify-center"
+        :class="{
+          'hover:bg-base-200': hasChildren,
+        }"
+      >
+        <div v-if="!hasChildren" class="h-6 w-6"></div>
+        <label
+          v-else
+          class="swap swap-rotate"
+          :class="{
+            'swap-active': openRef,
+          }"
+        >
+          <Icon name="mdi-chevron-right" class="h-6 w-6 swap-off" />
+          <Icon name="mdi-chevron-down" class="h-6 w-6 swap-on" />
+        </label>
+      </div>
+      <Icon name="mdi-map-marker" class="h-4 w-4" />
+      <NuxtLink class="hover:link text-lg" :to="link" @click.stop>{{ item.name }} </NuxtLink>
+    </div>
+    <div v-if="openRef" class="ml-4">
+      <LocationTreeNode v-for="child in item.children" :key="child.id" :item="child" :tree-id="treeId" />
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/frontend/components/Location/Tree/Node.vue
+++ b/frontend/components/Location/Tree/Node.vue
@@ -1,18 +1,15 @@
 <script setup lang="ts">
   import { useTreeState } from "./tree-state";
-  import { ItemSummary, TreeItem } from "~~/lib/api/types/data-contracts";
+  import { TreeItem } from "~~/lib/api/types/data-contracts";
 
   type Props = {
-    type?: "location" | "item";
     treeId: string;
     item: TreeItem;
   };
-  const props = withDefaults(defineProps<Props>(), {
-    type: "location",
-  });
+  const props = withDefaults(defineProps<Props>(), {});
 
   const link = computed(() => {
-    return props.type === "location" ? `/location/${props.item.id}` : `/item/${props.item.id}`;
+    return props.item.type === "location" ? `/location/${props.item.id}` : `/item/${props.item.id}`;
   });
 
   const hasChildren = computed(() => {
@@ -34,36 +31,6 @@
     // converts a UUID to a short hash
     return props.item.id.replace(/-/g, "").substring(0, 8);
   });
-
-  const api = useUserApi();
-
-  const hasFetched = ref(false);
-  const items = ref<ItemSummary[]>([]);
-
-  async function fetchItems() {
-    const { data, error } = await api.items.getAll({
-      locations: [props.item.id],
-    });
-
-    if (error) {
-      return;
-    }
-
-    hasFetched.value = true;
-    items.value = data.items;
-
-    console.log("fetched items", items.value);
-  }
-
-  watch(
-    openRef,
-    async value => {
-      if (value && !hasFetched.value && props.type === "location") {
-        await fetchItems();
-      }
-    },
-    { immediate: true }
-  );
 </script>
 
 <template>
@@ -93,7 +60,8 @@
           <Icon name="mdi-chevron-down" class="h-6 w-6 swap-on" />
         </label>
       </div>
-      <Icon name="mdi-map-marker" class="h-4 w-4" />
+      <Icon v-if="item.type === 'location'" name="mdi-map-marker" class="h-4 w-4" />
+      <Icon v-else name="mdi-package-variant" class="h-4 w-4" />
       <NuxtLink class="hover:link text-lg" :to="link" @click.stop>{{ item.name }} </NuxtLink>
     </div>
     <div v-if="openRef" class="ml-4">

--- a/frontend/components/Location/Tree/Root.vue
+++ b/frontend/components/Location/Tree/Root.vue
@@ -10,11 +10,9 @@
 </script>
 
 <template>
-  <BaseCard class="p-4">
-    <div class="p-4 border-2 root">
-      <LocationTreeNode v-for="item in locs" :key="item.id" :item="item" :tree-id="treeId" />
-    </div>
-  </BaseCard>
+  <div class="p-4 border-2 root">
+    <LocationTreeNode v-for="item in locs" :key="item.id" :item="item" :tree-id="treeId" />
+  </div>
 </template>
 
 <style></style>

--- a/frontend/components/Location/Tree/Root.vue
+++ b/frontend/components/Location/Tree/Root.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+  import { TreeItem } from "~~/lib/api/types/data-contracts";
+
+  type Props = {
+    locs: TreeItem[];
+    treeId: string;
+  };
+
+  defineProps<Props>();
+</script>
+
+<template>
+  <BaseCard class="p-4">
+    <div class="p-4 border-2 root">
+      <LocationTreeNode v-for="item in locs" :key="item.id" :item="item" :tree-id="treeId" />
+    </div>
+  </BaseCard>
+</template>
+
+<style></style>

--- a/frontend/components/Location/Tree/tree-state.ts
+++ b/frontend/components/Location/Tree/tree-state.ts
@@ -1,0 +1,17 @@
+import type { Ref } from "vue";
+
+type TreeState = Record<string, boolean>;
+
+const store: Record<string, Ref<TreeState>> = {};
+
+export function newTreeKey(): string {
+  return Math.random().toString(36).substring(2);
+}
+
+export function useTreeState(key: string): Ref<TreeState> {
+  if (!store[key]) {
+    store[key] = ref({});
+  }
+
+  return store[key];
+}

--- a/frontend/composables/use-location-helpers.ts
+++ b/frontend/composables/use-location-helpers.ts
@@ -1,0 +1,44 @@
+import { Ref } from "vue";
+import { TreeItem } from "~~/lib/api/types/data-contracts";
+
+export interface FlatTreeItem {
+  id: string;
+  name: string;
+  display: string;
+}
+
+export function flatTree(tree: TreeItem[]): Ref<FlatTreeItem[]> {
+  const v = ref<FlatTreeItem[]>([]);
+
+  // turns the nested items into a flat items array where
+  // the display is a string of the tree hierarchy separated by breadcrumbs
+
+  function flatten(items: TreeItem[], display: string) {
+    for (const item of items) {
+      v.value.push({
+        id: item.id,
+        name: item.name,
+        display: display + item.name,
+      });
+      if (item.children) {
+        flatten(item.children, display + item.name + " > ");
+      }
+    }
+  }
+
+  flatten(tree, "");
+
+  return v;
+}
+
+export async function useFlatLocations(): Promise<Ref<FlatTreeItem[]>> {
+  const api = useUserApi();
+
+  const locations = await api.locations.getTree();
+
+  if (!locations) {
+    return ref([]);
+  }
+
+  return flatTree(locations.data.items);
+}

--- a/frontend/composables/use-preferences.ts
+++ b/frontend/composables/use-preferences.ts
@@ -1,10 +1,13 @@
 import { Ref } from "vue";
 import { DaisyTheme } from "~~/lib/data/themes";
 
+export type ViewType = "table" | "card" | "tree";
+
 export type LocationViewPreferences = {
   showDetails: boolean;
   showEmpty: boolean;
   editorAdvancedView: boolean;
+  itemDisplayView: ViewType;
   theme: DaisyTheme;
 };
 
@@ -19,6 +22,7 @@ export function useViewPreferences(): Ref<LocationViewPreferences> {
       showDetails: true,
       showEmpty: true,
       editorAdvancedView: false,
+      itemDisplayView: "card",
       theme: "homebox",
     },
     { mergeDefaults: true }

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -165,6 +165,13 @@
       to: "/items",
     },
     {
+      icon: "mdi-map-marker",
+      id: 4,
+      active: computed(() => route.path === "/locations"),
+      name: "Locations",
+      to: "/locations",
+    },
+    {
       icon: "mdi-database",
       id: 2,
       name: "Import",

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -158,10 +158,10 @@
       to: "/profile",
     },
     {
-      icon: "mdi-document",
+      icon: "mdi-magnify",
       id: 3,
       active: computed(() => route.path === "/items"),
-      name: "Items",
+      name: "Search",
       to: "/items",
     },
     {
@@ -179,14 +179,6 @@
         modals.import = true;
       },
     },
-    // {
-    //   icon: "mdi-database-export",
-    //   id: 5,
-    //   name: "Export",
-    //   action: () => {
-    //     console.log("Export");
-    //   },
-    // },
   ];
 
   const labelStore = useLabelStore();

--- a/frontend/lib/api/classes/locations.ts
+++ b/frontend/lib/api/classes/locations.ts
@@ -6,13 +6,17 @@ export type LocationsQuery = {
   filterChildren: boolean;
 };
 
+export type TreeQuery = {
+  withItems: boolean;
+};
+
 export class LocationsApi extends BaseAPI {
   getAll(q: LocationsQuery = { filterChildren: false }) {
     return this.http.get<Results<LocationOutCount>>({ url: route("/locations", q) });
   }
 
-  getTree() {
-    return this.http.get<Results<TreeItem>>({ url: route("/locations/tree") });
+  getTree(tq = { withItems: false }) {
+    return this.http.get<Results<TreeItem>>({ url: route("/locations/tree", tq) });
   }
 
   create(body: LocationCreate) {

--- a/frontend/lib/api/classes/locations.ts
+++ b/frontend/lib/api/classes/locations.ts
@@ -1,5 +1,5 @@
 import { BaseAPI, route } from "../base";
-import { LocationOutCount, LocationCreate, LocationOut, LocationUpdate } from "../types/data-contracts";
+import { LocationOutCount, LocationCreate, LocationOut, LocationUpdate, TreeItem } from "../types/data-contracts";
 import { Results } from "../types/non-generated";
 
 export type LocationsQuery = {
@@ -9,6 +9,10 @@ export type LocationsQuery = {
 export class LocationsApi extends BaseAPI {
   getAll(q: LocationsQuery = { filterChildren: false }) {
     return this.http.get<Results<LocationOutCount>>({ url: route("/locations", q) });
+  }
+
+  getTree() {
+    return this.http.get<Results<TreeItem>>({ url: route("/locations/tree") });
   }
 
   create(body: LocationCreate) {

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -229,7 +229,7 @@ export interface LocationUpdate {
 export interface MaintenanceEntry {
   /** @example "0" */
   cost: string;
-  date: string;
+  date: Date;
   description: string;
   id: string;
   name: string;
@@ -238,7 +238,7 @@ export interface MaintenanceEntry {
 export interface MaintenanceEntryCreate {
   /** @example "0" */
   cost: string;
-  date: string;
+  date: Date;
   description: string;
   name: string;
 }
@@ -246,7 +246,7 @@ export interface MaintenanceEntryCreate {
 export interface MaintenanceEntryUpdate {
   /** @example "0" */
   cost: string;
-  date: string;
+  date: Date;
   description: string;
   name: string;
 }
@@ -258,7 +258,7 @@ export interface MaintenanceLog {
   itemId: string;
 }
 
-export interface PaginationResultItemSummary {
+export interface PaginationResultRepoItemSummary {
   items: ItemSummary[];
   page: number;
   pageSize: number;
@@ -302,7 +302,7 @@ export interface ValueOverTime {
 }
 
 export interface ValueOverTimeEntry {
-  date: string;
+  date: Date;
   name: string;
   value: number;
 }

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -17,11 +17,11 @@ export interface DocumentOut {
 }
 
 export interface Group {
-  createdAt: string;
+  createdAt: Date;
   currency: string;
   id: string;
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface GroupStatistics {
@@ -39,11 +39,11 @@ export interface GroupUpdate {
 }
 
 export interface ItemAttachment {
-  createdAt: string;
+  createdAt: Date;
   document: DocumentOut;
   id: string;
   type: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface ItemAttachmentUpdate {
@@ -76,7 +76,7 @@ export interface ItemOut {
   assetId: string;
   attachments: ItemAttachment[];
   children: ItemSummary[];
-  createdAt: string;
+  createdAt: Date;
   description: string;
   fields: ItemField[];
   id: string;
@@ -96,23 +96,23 @@ export interface ItemOut {
   /** @example "0" */
   purchasePrice: string;
   /** Purchase */
-  purchaseTime: string;
+  purchaseTime: Date;
   quantity: number;
   serialNumber: string;
   soldNotes: string;
   /** @example "0" */
   soldPrice: string;
   /** Sold */
-  soldTime: string;
+  soldTime: Date;
   soldTo: string;
-  updatedAt: string;
+  updatedAt: Date;
   warrantyDetails: string;
-  warrantyExpires: string;
+  warrantyExpires: Date;
 }
 
 export interface ItemSummary {
   archived: boolean;
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   insured: boolean;
@@ -123,7 +123,7 @@ export interface ItemSummary {
   /** @example "0" */
   purchasePrice: string;
   quantity: number;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface ItemUpdate {
@@ -148,7 +148,7 @@ export interface ItemUpdate {
   /** @example "0" */
   purchasePrice: string;
   /** Purchase */
-  purchaseTime: string;
+  purchaseTime: Date;
   quantity: number;
   /** Identifications */
   serialNumber: string;
@@ -156,10 +156,10 @@ export interface ItemUpdate {
   /** @example "0" */
   soldPrice: string;
   /** Sold */
-  soldTime: string;
+  soldTime: Date;
   soldTo: string;
   warrantyDetails: string;
-  warrantyExpires: string;
+  warrantyExpires: Date;
 }
 
 export interface LabelCreate {
@@ -169,53 +169,54 @@ export interface LabelCreate {
 }
 
 export interface LabelOut {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   items: ItemSummary[];
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LabelSummary {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LocationCreate {
   description: string;
   name: string;
+  parentId: string | null;
 }
 
 export interface LocationOut {
   children: LocationSummary[];
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   items: ItemSummary[];
   name: string;
   parent: LocationSummary;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LocationOutCount {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   itemCount: number;
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LocationSummary {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LocationUpdate {
@@ -228,7 +229,7 @@ export interface LocationUpdate {
 export interface MaintenanceEntry {
   /** @example "0" */
   cost: string;
-  date: string;
+  date: Date;
   description: string;
   id: string;
   name: string;
@@ -237,7 +238,7 @@ export interface MaintenanceEntry {
 export interface MaintenanceEntryCreate {
   /** @example "0" */
   cost: string;
-  date: string;
+  date: Date;
   description: string;
   name: string;
 }
@@ -245,7 +246,7 @@ export interface MaintenanceEntryCreate {
 export interface MaintenanceEntryUpdate {
   /** @example "0" */
   cost: string;
-  date: string;
+  date: Date;
   description: string;
   name: string;
 }
@@ -257,7 +258,7 @@ export interface MaintenanceLog {
   itemId: string;
 }
 
-export interface PaginationResultRepoItemSummary {
+export interface PaginationResultItemSummary {
   items: ItemSummary[];
   page: number;
   pageSize: number;
@@ -300,7 +301,7 @@ export interface ValueOverTime {
 }
 
 export interface ValueOverTimeEntry {
-  date: string;
+  date: Date;
   name: string;
   value: number;
 }
@@ -353,13 +354,13 @@ export interface EnsureAssetIDResult {
 }
 
 export interface GroupInvitation {
-  expiresAt: string;
+  expiresAt: Date;
   token: string;
   uses: number;
 }
 
 export interface GroupInvitationCreate {
-  expiresAt: string;
+  expiresAt: Date;
   uses: number;
 }
 
@@ -369,6 +370,6 @@ export interface ItemAttachmentToken {
 
 export interface TokenResponse {
   attachmentToken: string;
-  expiresAt: string;
+  expiresAt: Date;
   token: string;
 }

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -17,11 +17,11 @@ export interface DocumentOut {
 }
 
 export interface Group {
-  createdAt: string;
+  createdAt: Date;
   currency: string;
   id: string;
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface GroupStatistics {
@@ -39,11 +39,11 @@ export interface GroupUpdate {
 }
 
 export interface ItemAttachment {
-  createdAt: string;
+  createdAt: Date;
   document: DocumentOut;
   id: string;
   type: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface ItemAttachmentUpdate {
@@ -76,7 +76,7 @@ export interface ItemOut {
   assetId: string;
   attachments: ItemAttachment[];
   children: ItemSummary[];
-  createdAt: string;
+  createdAt: Date;
   description: string;
   fields: ItemField[];
   id: string;
@@ -103,16 +103,16 @@ export interface ItemOut {
   /** @example "0" */
   soldPrice: string;
   /** Sold */
-  soldTime: string;
+  soldTime: Date;
   soldTo: string;
-  updatedAt: string;
+  updatedAt: Date;
   warrantyDetails: string;
-  warrantyExpires: string;
+  warrantyExpires: Date;
 }
 
 export interface ItemSummary {
   archived: boolean;
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   insured: boolean;
@@ -123,7 +123,7 @@ export interface ItemSummary {
   /** @example "0" */
   purchasePrice: string;
   quantity: number;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface ItemUpdate {
@@ -156,10 +156,10 @@ export interface ItemUpdate {
   /** @example "0" */
   soldPrice: string;
   /** Sold */
-  soldTime: string;
+  soldTime: Date;
   soldTo: string;
   warrantyDetails: string;
-  warrantyExpires: string;
+  warrantyExpires: Date;
 }
 
 export interface LabelCreate {
@@ -169,20 +169,20 @@ export interface LabelCreate {
 }
 
 export interface LabelOut {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   items: ItemSummary[];
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LabelSummary {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LocationCreate {
@@ -193,30 +193,30 @@ export interface LocationCreate {
 
 export interface LocationOut {
   children: LocationSummary[];
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   items: ItemSummary[];
   name: string;
   parent: LocationSummary;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LocationOutCount {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   itemCount: number;
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LocationSummary {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   name: string;
-  updatedAt: string;
+  updatedAt: Date;
 }
 
 export interface LocationUpdate {
@@ -229,7 +229,7 @@ export interface LocationUpdate {
 export interface MaintenanceEntry {
   /** @example "0" */
   cost: string;
-  date: Date;
+  date: string;
   description: string;
   id: string;
   name: string;
@@ -238,7 +238,7 @@ export interface MaintenanceEntry {
 export interface MaintenanceEntryCreate {
   /** @example "0" */
   cost: string;
-  date: Date;
+  date: string;
   description: string;
   name: string;
 }
@@ -246,7 +246,7 @@ export interface MaintenanceEntryCreate {
 export interface MaintenanceEntryUpdate {
   /** @example "0" */
   cost: string;
-  date: Date;
+  date: string;
   description: string;
   name: string;
 }
@@ -275,6 +275,7 @@ export interface TreeItem {
   children: TreeItem[];
   id: string;
   name: string;
+  type: string;
 }
 
 export interface UserOut {
@@ -301,7 +302,7 @@ export interface ValueOverTime {
 }
 
 export interface ValueOverTimeEntry {
-  date: Date;
+  date: string;
   name: string;
   value: number;
 }

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -17,11 +17,11 @@ export interface DocumentOut {
 }
 
 export interface Group {
-  createdAt: Date;
+  createdAt: string;
   currency: string;
   id: string;
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface GroupStatistics {
@@ -39,11 +39,11 @@ export interface GroupUpdate {
 }
 
 export interface ItemAttachment {
-  createdAt: Date;
+  createdAt: string;
   document: DocumentOut;
   id: string;
   type: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface ItemAttachmentUpdate {
@@ -76,7 +76,7 @@ export interface ItemOut {
   assetId: string;
   attachments: ItemAttachment[];
   children: ItemSummary[];
-  createdAt: Date;
+  createdAt: string;
   description: string;
   fields: ItemField[];
   id: string;
@@ -103,16 +103,16 @@ export interface ItemOut {
   /** @example "0" */
   soldPrice: string;
   /** Sold */
-  soldTime: Date;
+  soldTime: string;
   soldTo: string;
-  updatedAt: Date;
+  updatedAt: string;
   warrantyDetails: string;
-  warrantyExpires: Date;
+  warrantyExpires: string;
 }
 
 export interface ItemSummary {
   archived: boolean;
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   insured: boolean;
@@ -123,7 +123,7 @@ export interface ItemSummary {
   /** @example "0" */
   purchasePrice: string;
   quantity: number;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface ItemUpdate {
@@ -156,10 +156,10 @@ export interface ItemUpdate {
   /** @example "0" */
   soldPrice: string;
   /** Sold */
-  soldTime: Date;
+  soldTime: string;
   soldTo: string;
   warrantyDetails: string;
-  warrantyExpires: Date;
+  warrantyExpires: string;
 }
 
 export interface LabelCreate {
@@ -169,20 +169,20 @@ export interface LabelCreate {
 }
 
 export interface LabelOut {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   items: ItemSummary[];
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LabelSummary {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LocationCreate {
@@ -193,30 +193,30 @@ export interface LocationCreate {
 
 export interface LocationOut {
   children: LocationSummary[];
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   items: ItemSummary[];
   name: string;
   parent: LocationSummary;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LocationOutCount {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   itemCount: number;
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LocationSummary {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LocationUpdate {

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -17,11 +17,11 @@ export interface DocumentOut {
 }
 
 export interface Group {
-  createdAt: Date;
+  createdAt: string;
   currency: string;
   id: string;
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface GroupStatistics {
@@ -39,11 +39,11 @@ export interface GroupUpdate {
 }
 
 export interface ItemAttachment {
-  createdAt: Date;
+  createdAt: string;
   document: DocumentOut;
   id: string;
   type: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface ItemAttachmentUpdate {
@@ -76,7 +76,7 @@ export interface ItemOut {
   assetId: string;
   attachments: ItemAttachment[];
   children: ItemSummary[];
-  createdAt: Date;
+  createdAt: string;
   description: string;
   fields: ItemField[];
   id: string;
@@ -96,23 +96,23 @@ export interface ItemOut {
   /** @example "0" */
   purchasePrice: string;
   /** Purchase */
-  purchaseTime: Date;
+  purchaseTime: string;
   quantity: number;
   serialNumber: string;
   soldNotes: string;
   /** @example "0" */
   soldPrice: string;
   /** Sold */
-  soldTime: Date;
+  soldTime: string;
   soldTo: string;
-  updatedAt: Date;
+  updatedAt: string;
   warrantyDetails: string;
-  warrantyExpires: Date;
+  warrantyExpires: string;
 }
 
 export interface ItemSummary {
   archived: boolean;
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   insured: boolean;
@@ -123,7 +123,7 @@ export interface ItemSummary {
   /** @example "0" */
   purchasePrice: string;
   quantity: number;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface ItemUpdate {
@@ -148,7 +148,7 @@ export interface ItemUpdate {
   /** @example "0" */
   purchasePrice: string;
   /** Purchase */
-  purchaseTime: Date;
+  purchaseTime: string;
   quantity: number;
   /** Identifications */
   serialNumber: string;
@@ -156,10 +156,10 @@ export interface ItemUpdate {
   /** @example "0" */
   soldPrice: string;
   /** Sold */
-  soldTime: Date;
+  soldTime: string;
   soldTo: string;
   warrantyDetails: string;
-  warrantyExpires: Date;
+  warrantyExpires: string;
 }
 
 export interface LabelCreate {
@@ -169,20 +169,20 @@ export interface LabelCreate {
 }
 
 export interface LabelOut {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   items: ItemSummary[];
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LabelSummary {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LocationCreate {
@@ -192,30 +192,30 @@ export interface LocationCreate {
 
 export interface LocationOut {
   children: LocationSummary[];
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   items: ItemSummary[];
   name: string;
   parent: LocationSummary;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LocationOutCount {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   itemCount: number;
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LocationSummary {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   name: string;
-  updatedAt: Date;
+  updatedAt: string;
 }
 
 export interface LocationUpdate {
@@ -228,7 +228,7 @@ export interface LocationUpdate {
 export interface MaintenanceEntry {
   /** @example "0" */
   cost: string;
-  date: Date;
+  date: string;
   description: string;
   id: string;
   name: string;
@@ -237,7 +237,7 @@ export interface MaintenanceEntry {
 export interface MaintenanceEntryCreate {
   /** @example "0" */
   cost: string;
-  date: Date;
+  date: string;
   description: string;
   name: string;
 }
@@ -245,7 +245,7 @@ export interface MaintenanceEntryCreate {
 export interface MaintenanceEntryUpdate {
   /** @example "0" */
   cost: string;
-  date: Date;
+  date: string;
   description: string;
   name: string;
 }
@@ -268,6 +268,12 @@ export interface TotalsByOrganizer {
   id: string;
   name: string;
   total: number;
+}
+
+export interface TreeItem {
+  children: TreeItem[];
+  id: string;
+  name: string;
 }
 
 export interface UserOut {
@@ -294,7 +300,7 @@ export interface ValueOverTime {
 }
 
 export interface ValueOverTimeEntry {
-  date: Date;
+  date: string;
   name: string;
   value: number;
 }

--- a/frontend/lib/data/currency.ts
+++ b/frontend/lib/data/currency.ts
@@ -1,5 +1,6 @@
 export type Codes = "USD" | "EUR" | "GBP" | "JPY" | "ZAR" | "AUD" | "NOK" | "SEK" | "DKK" | "INR" | "RMB" | "BGN";
 
+
 export type Currency = {
   code: Codes;
   local: string;

--- a/frontend/lib/data/currency.ts
+++ b/frontend/lib/data/currency.ts
@@ -1,6 +1,5 @@
 export type Codes = "USD" | "EUR" | "GBP" | "JPY" | "ZAR" | "AUD" | "NOK" | "SEK" | "DKK" | "INR" | "RMB" | "BGN";
 
-
 export type Currency = {
   code: Codes;
   local: string;

--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -406,9 +406,7 @@
           </ul>
         </div>
         <template #description>
-          <p class="text-lg">
-            {{ item ? item.description : "" }}
-          </p>
+          <Markdown :source="item.description"> </Markdown>
           <div class="flex flex-wrap gap-2 mt-3">
             <NuxtLink ref="badge" class="badge p-3" :to="`/location/${item.location.id}`">
               <Icon name="heroicons-map-pin" class="mr-2 swap-on"></Icon>

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -358,13 +358,7 @@
             </template>
           </BaseSectionHeader>
           <div class="px-5 mb-6 grid md:grid-cols-2 gap-4">
-            <FormSelect
-              v-if="item"
-              v-model="item.location"
-              label="Location"
-              :items="locations ?? []"
-              compare-key="id"
-            />
+            <LocationSelector v-model="item.location" />
             <FormMultiselect v-model="item.labels" label="Labels" :items="labels ?? []" />
 
             <Autocomplete

--- a/frontend/pages/item/[id]/index/log.vue
+++ b/frontend/pages/item/[id]/index/log.vue
@@ -114,8 +114,6 @@
     entry.date = new Date(e.date);
     entry.description = e.description;
     entry.cost = e.cost;
-
-    console.log(e);
   }
 
   async function editEntry() {

--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -9,7 +9,7 @@
   });
 
   useHead({
-    title: "Homebox | Home",
+    title: "Homebox | Items",
   });
 
   const searchLocked = ref(false);

--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -179,12 +179,9 @@
         <DetailsSection :details="details" />
       </BaseCard>
 
-      <section v-if="location && location.items.length > 0">
-        <BaseSectionHeader class="mb-5"> Items </BaseSectionHeader>
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-          <ItemCard v-for="item in location.items" :key="item.id" :item="item" />
-        </div>
-      </section>
+      <template v-if="location && location.items.length > 0">
+        <ItemViewSelectable :items="location.items" />
+      </template>
 
       <section v-if="location && location.children.length > 0">
         <BaseSectionHeader class="mb-5"> Child Locations </BaseSectionHeader>

--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -131,7 +131,7 @@
       <form v-if="location" @submit.prevent="update">
         <FormTextField v-model="updateData.name" :autofocus="true" label="Location Name" />
         <FormTextArea v-model="updateData.description" label="Location Description" />
-        <FormAutocomplete v-model="parent" :items="locations" item-text="name" item-value="id" label="Parent" />
+        <LocationSelector v-model="parent" />
         <div class="modal-action">
           <BaseButton type="submit" :loading="updating"> Update </BaseButton>
         </div>

--- a/frontend/pages/locations.vue
+++ b/frontend/pages/locations.vue
@@ -12,7 +12,9 @@
   const api = useUserApi();
 
   const { data: tree } = useAsyncData(async () => {
-    const { data, error } = await api.locations.getTree();
+    const { data, error } = await api.locations.getTree({
+      withItems: true,
+    });
 
     if (error) {
       return [];
@@ -32,7 +34,7 @@
     const query = route.currentRoute.value.query;
 
     if (query && query[locationTreeId]) {
-      console.log("setting tree state from query params");
+      console.debug("setting tree state from query params");
       const data = JSON.parse(query[locationTreeId] as string);
 
       for (const key in data) {
@@ -49,12 +51,28 @@
     },
     { deep: true }
   );
+
+  function closeAll() {
+    for (const key in treeState.value) {
+      treeState.value[key] = false;
+    }
+  }
 </script>
 
 <template>
   <BaseContainer class="mb-16">
     <BaseSectionHeader> Locations </BaseSectionHeader>
-
-    <LocationTreeRoot v-if="tree" :locs="tree" :tree-id="locationTreeId" />
+    <BaseCard>
+      <div class="p-4">
+        <div class="flex justify-end mb-2">
+          <div class="btn-group">
+            <button class="btn btn-sm tooltip tooltip-top" data-tip="Collapse Tree" @click="closeAll">
+              <Icon name="mdi-collapse-all-outline" />
+            </button>
+          </div>
+        </div>
+        <LocationTreeRoot v-if="tree" :locs="tree" :tree-id="locationTreeId" />
+      </div>
+    </BaseCard>
   </BaseContainer>
 </template>

--- a/frontend/pages/locations.vue
+++ b/frontend/pages/locations.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+  import { useTreeState } from "~~/components/Location/Tree/tree-state";
+
+  definePageMeta({
+    middleware: ["auth"],
+  });
+
+  useHead({
+    title: "Homebox | Items",
+  });
+
+  const api = useUserApi();
+
+  const { data: tree } = useAsyncData(async () => {
+    const { data, error } = await api.locations.getTree();
+
+    if (error) {
+      return [];
+    }
+
+    return data.items;
+  });
+
+  const locationTreeId = "locationTree";
+
+  const treeState = useTreeState(locationTreeId);
+
+  const route = useRouter();
+
+  onMounted(() => {
+    // set tree state from query params
+    const query = route.currentRoute.value.query;
+
+    if (query && query[locationTreeId]) {
+      console.log("setting tree state from query params");
+      const data = JSON.parse(query[locationTreeId] as string);
+
+      for (const key in data) {
+        treeState.value[key] = data[key];
+      }
+    }
+  });
+
+  watch(
+    treeState,
+    () => {
+      // Push the current state to the URL
+      route.replace({ query: { [locationTreeId]: JSON.stringify(treeState.value) } });
+    },
+    { deep: true }
+  );
+</script>
+
+<template>
+  <BaseContainer class="mb-16">
+    <BaseSectionHeader> Locations </BaseSectionHeader>
+
+    <LocationTreeRoot v-if="tree" :locs="tree" :tree-id="locationTreeId" />
+  </BaseContainer>
+</template>

--- a/frontend/plugins/scroll.client.ts
+++ b/frontend/plugins/scroll.client.ts
@@ -1,7 +1,5 @@
 export default defineNuxtPlugin(nuxtApp => {
   nuxtApp.hook("page:finish", () => {
-    console.log(document.body);
     document.body.scrollTo({ top: 0 });
-    console.log("page:finish");
   });
 });


### PR DESCRIPTION
## Description

This PR adds a new locations tree-like view to display locations and the associated items

Closes #240
Closes #139

Currently the entire tree is returned instead of lazy loading, this happens pretty fast for what I've tested with but this may need to be improved in the future. 

### Navigation Bar

![CleanShot 2023-01-28 at 11 32 55](https://user-images.githubusercontent.com/64056131/215289573-b3df0015-3daa-48f0-91d8-0f75b5950032.png)

### Tree View

- Links to Item/Location Pages

![CleanShot 2023-01-28 at 11 33 17](https://user-images.githubusercontent.com/64056131/215289623-fce8fbf5-c58e-485d-981f-f5f5088aba01.png)


### Location Selector

- Now shows nesting of locations

![CleanShot 2023-01-28 at 11 34 56](https://user-images.githubusercontent.com/64056131/215289651-4d14a021-f9a3-4557-a341-d07637a3ffa1.png)
