### PR TITLE
fix: add custom action for fixing broken date/times

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_actions.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_actions.go
@@ -9,15 +9,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type EnsureAssetIDResult struct {
+type ActionAmountResult struct {
 	Completed int `json:"completed"`
 }
 
 // HandleGroupInvitationsCreate godoc
-// @Summary  Get the current user
+// @Summary  Ensures all items in the database have an asset id
 // @Tags     Group
 // @Produce  json
-// @Success  200     {object} EnsureAssetIDResult
+// @Success  200     {object} ActionAmountResult
 // @Router   /v1/actions/ensure-asset-ids [Post]
 // @Security Bearer
 func (ctrl *V1Controller) HandleEnsureAssetID() server.HandlerFunc {
@@ -30,6 +30,27 @@ func (ctrl *V1Controller) HandleEnsureAssetID() server.HandlerFunc {
 			return validate.NewRequestError(err, http.StatusInternalServerError)
 		}
 
-		return server.Respond(w, http.StatusOK, EnsureAssetIDResult{Completed: totalCompleted})
+		return server.Respond(w, http.StatusOK, ActionAmountResult{Completed: totalCompleted})
+	}
+}
+
+// HandleItemDateZeroOut godoc
+// @Summary  Resets all item date fields to the beginning of the day
+// @Tags     Group
+// @Produce  json
+// @Success  200     {object} ActionAmountResult
+// @Router   /v1/actions/zero-item-time-fields [Post]
+// @Security Bearer
+func (ctrl *V1Controller) HandleItemDateZeroOut() server.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		ctx := services.NewContext(r.Context())
+
+		totalCompleted, err := ctrl.repo.Items.ZeroOutTimeFields(ctx, ctx.GID)
+		if err != nil {
+			log.Err(err).Msg("failed to ensure asset id")
+			return validate.NewRequestError(err, http.StatusInternalServerError)
+		}
+
+		return server.Respond(w, http.StatusOK, ActionAmountResult{Completed: totalCompleted})
 	}
 }

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -88,6 +88,7 @@ func (a *app) mountRoutes(repos *repo.AllRepos) {
 	a.server.Put(v1Base("/groups"), v1Ctrl.HandleGroupUpdate(), userMW...)
 
 	a.server.Post(v1Base("/actions/ensure-asset-ids"), v1Ctrl.HandleEnsureAssetID(), userMW...)
+	a.server.Post(v1Base("/actions/zero-item-time-fields"), v1Ctrl.HandleItemDateZeroOut(), userMW...)
 
 	a.server.Get(v1Base("/locations"), v1Ctrl.HandleLocationGetAll(), userMW...)
 	a.server.Post(v1Base("/locations"), v1Ctrl.HandleLocationCreate(), userMW...)

--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -34,12 +34,36 @@ const docTemplate = `{
                 "tags": [
                     "Group"
                 ],
-                "summary": "Get the current user",
+                "summary": "Ensures all items in the database have an asset id",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v1.EnsureAssetIDResult"
+                            "$ref": "#/definitions/v1.ActionAmountResult"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/actions/zero-item-time-fields": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Resets all item date fields to the beginning of the day",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.ActionAmountResult"
                         }
                     }
                 }
@@ -2365,6 +2389,14 @@ const docTemplate = `{
                 }
             }
         },
+        "v1.ActionAmountResult": {
+            "type": "object",
+            "properties": {
+                "completed": {
+                    "type": "integer"
+                }
+            }
+        },
         "v1.ApiSummary": {
             "type": "object",
             "properties": {
@@ -2413,14 +2445,6 @@ const docTemplate = `{
                 },
                 "new": {
                     "type": "string"
-                }
-            }
-        },
-        "v1.EnsureAssetIDResult": {
-            "type": "object",
-            "properties": {
-                "completed": {
-                    "type": "integer"
                 }
             }
         },

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -26,12 +26,36 @@
                 "tags": [
                     "Group"
                 ],
-                "summary": "Get the current user",
+                "summary": "Ensures all items in the database have an asset id",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v1.EnsureAssetIDResult"
+                            "$ref": "#/definitions/v1.ActionAmountResult"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/actions/zero-item-time-fields": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Resets all item date fields to the beginning of the day",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.ActionAmountResult"
                         }
                     }
                 }
@@ -2357,6 +2381,14 @@
                 }
             }
         },
+        "v1.ActionAmountResult": {
+            "type": "object",
+            "properties": {
+                "completed": {
+                    "type": "integer"
+                }
+            }
+        },
         "v1.ApiSummary": {
             "type": "object",
             "properties": {
@@ -2405,14 +2437,6 @@
                 },
                 "new": {
                     "type": "string"
-                }
-            }
-        },
-        "v1.EnsureAssetIDResult": {
-            "type": "object",
-            "properties": {
-                "completed": {
-                    "type": "integer"
                 }
             }
         },

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -556,6 +556,11 @@ definitions:
       token:
         type: string
     type: object
+  v1.ActionAmountResult:
+    properties:
+      completed:
+        type: integer
+    type: object
   v1.ApiSummary:
     properties:
       build:
@@ -588,11 +593,6 @@ definitions:
         type: string
       new:
         type: string
-    type: object
-  v1.EnsureAssetIDResult:
-    properties:
-      completed:
-        type: integer
     type: object
   v1.GroupInvitation:
     properties:
@@ -643,10 +643,24 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/v1.EnsureAssetIDResult'
+            $ref: '#/definitions/v1.ActionAmountResult'
       security:
       - Bearer: []
-      summary: Get the current user
+      summary: Ensures all items in the database have an asset id
+      tags:
+      - Group
+  /v1/actions/zero-item-time-fields:
+    post:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.ActionAmountResult'
+      security:
+      - Bearer: []
+      summary: Resets all item date fields to the beginning of the day
       tags:
       - Group
   /v1/assets/{id}:

--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -5,3 +5,4 @@
 .btn {
     text-transform: none !important;
 }
+

--- a/frontend/components/Form/DatePicker.vue
+++ b/frontend/components/Form/DatePicker.vue
@@ -31,7 +31,11 @@
   const selected = computed({
     get() {
       // return modelValue as string as YYYY-MM-DD or null
-      return props.modelValue ? props.modelValue.toISOString().split("T")[0] : null;
+      if (validDate(props.modelValue)) {
+        return props.modelValue ? props.modelValue.toISOString().split("T")[0] : null;
+      }
+
+      return null;
     },
     set(value: string | null) {
       // emit update:modelValue with a Date object or null

--- a/frontend/lib/api/classes/actions.ts
+++ b/frontend/lib/api/classes/actions.ts
@@ -1,10 +1,16 @@
 import { BaseAPI, route } from "../base";
-import { EnsureAssetIDResult } from "../types/data-contracts";
+import { ActionAmountResult } from "../types/data-contracts";
 
 export class ActionsAPI extends BaseAPI {
   ensureAssetIDs() {
-    return this.http.post<void, EnsureAssetIDResult>({
+    return this.http.post<void, ActionAmountResult>({
       url: route("/actions/ensure-asset-ids"),
+    });
+  }
+
+  resetItemDateTimes() {
+    return this.http.post<void, ActionAmountResult>({
+      url: route("/actions/zero-item-time-fields"),
     });
   }
 }

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -17,7 +17,7 @@ export interface DocumentOut {
 }
 
 export interface Group {
-  createdAt: string;
+  createdAt: Date;
   currency: string;
   id: string;
   name: string;
@@ -39,7 +39,7 @@ export interface GroupUpdate {
 }
 
 export interface ItemAttachment {
-  createdAt: string;
+  createdAt: Date;
   document: DocumentOut;
   id: string;
   type: string;
@@ -76,7 +76,7 @@ export interface ItemOut {
   assetId: string;
   attachments: ItemAttachment[];
   children: ItemSummary[];
-  createdAt: string;
+  createdAt: Date;
   description: string;
   fields: ItemField[];
   id: string;
@@ -96,7 +96,7 @@ export interface ItemOut {
   /** @example "0" */
   purchasePrice: string;
   /** Purchase */
-  purchaseTime: Date;
+  purchaseTime: string;
   quantity: number;
   serialNumber: string;
   soldNotes: string;
@@ -112,7 +112,7 @@ export interface ItemOut {
 
 export interface ItemSummary {
   archived: boolean;
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   insured: boolean;
@@ -148,7 +148,7 @@ export interface ItemUpdate {
   /** @example "0" */
   purchasePrice: string;
   /** Purchase */
-  purchaseTime: Date;
+  purchaseTime: string;
   quantity: number;
   /** Identifications */
   serialNumber: string;
@@ -169,7 +169,7 @@ export interface LabelCreate {
 }
 
 export interface LabelOut {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   items: ItemSummary[];
@@ -178,7 +178,7 @@ export interface LabelOut {
 }
 
 export interface LabelSummary {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   name: string;
@@ -193,7 +193,7 @@ export interface LocationCreate {
 
 export interface LocationOut {
   children: LocationSummary[];
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   items: ItemSummary[];
@@ -203,7 +203,7 @@ export interface LocationOut {
 }
 
 export interface LocationOutCount {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   itemCount: number;
@@ -212,7 +212,7 @@ export interface LocationOutCount {
 }
 
 export interface LocationSummary {
-  createdAt: string;
+  createdAt: Date;
   description: string;
   id: string;
   name: string;
@@ -229,7 +229,7 @@ export interface LocationUpdate {
 export interface MaintenanceEntry {
   /** @example "0" */
   cost: string;
-  date: Date;
+  date: string;
   description: string;
   id: string;
   name: string;
@@ -238,7 +238,7 @@ export interface MaintenanceEntry {
 export interface MaintenanceEntryCreate {
   /** @example "0" */
   cost: string;
-  date: Date;
+  date: string;
   description: string;
   name: string;
 }
@@ -246,7 +246,7 @@ export interface MaintenanceEntryCreate {
 export interface MaintenanceEntryUpdate {
   /** @example "0" */
   cost: string;
-  date: Date;
+  date: string;
   description: string;
   name: string;
 }
@@ -258,7 +258,7 @@ export interface MaintenanceLog {
   itemId: string;
 }
 
-export interface PaginationResultRepoItemSummary {
+export interface PaginationResultItemSummary {
   items: ItemSummary[];
   page: number;
   pageSize: number;
@@ -302,7 +302,7 @@ export interface ValueOverTime {
 }
 
 export interface ValueOverTimeEntry {
-  date: Date;
+  date: string;
   name: string;
   value: number;
 }
@@ -330,6 +330,10 @@ export interface UserRegistration {
   token: string;
 }
 
+export interface ActionAmountResult {
+  completed: number;
+}
+
 export interface ApiSummary {
   build: Build;
   demo: boolean;
@@ -350,18 +354,14 @@ export interface ChangePassword {
   new: string;
 }
 
-export interface EnsureAssetIDResult {
-  completed: number;
-}
-
 export interface GroupInvitation {
-  expiresAt: Date;
+  expiresAt: string;
   token: string;
   uses: number;
 }
 
 export interface GroupInvitationCreate {
-  expiresAt: Date;
+  expiresAt: string;
   uses: number;
 }
 
@@ -371,6 +371,6 @@ export interface ItemAttachmentToken {
 
 export interface TokenResponse {
   attachmentToken: string;
-  expiresAt: Date;
+  expiresAt: string;
   token: string;
 }

--- a/frontend/pages/profile.vue
+++ b/frontend/pages/profile.vue
@@ -180,6 +180,25 @@
 
     notify.success(`${result.data.completed} assets have been updated.`);
   }
+
+  async function resetItemDateTimes() {
+    const { isCanceled } = await confirm.open(
+      "Are you sure you want to reset all date and time values? This will take a while and cannot be undone."
+    );
+
+    if (isCanceled) {
+      return;
+    }
+
+    const result = await api.actions.resetItemDateTimes();
+
+    if (result.error) {
+      notify.error("Failed to reset date and time values.");
+      return;
+    }
+
+    notify.success(`${result.data.completed} assets have been updated.`);
+  }
 </script>
 
 <template>
@@ -313,7 +332,7 @@
             </template>
           </BaseSectionHeader>
 
-          <div class="py-4 border-t-2 border-gray-300">
+          <div class="py-4 border-t-2 border-gray-300 space-y-8">
             <div class="grid grid-cols-1 md:grid-cols-4 gap-10">
               <div class="col-span-3">
                 <h4>Manage Asset IDs</h4>
@@ -324,6 +343,20 @@
                 </p>
               </div>
               <BaseButton class="btn-primary mt-auto" @click="ensureAssetIDs"> Ensure Asset IDs </BaseButton>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-10">
+              <div class="col-span-3">
+                <h4>Zero Item Date Times</h4>
+                <p class="text-sm">
+                  Resets the time value for all date time fields in your inventory to the beginning of the date. This is
+                  to fix a bug that was introduced early on in the development of the site that caused the time value to
+                  be stored with the time which caused issues with date fields displaying accurate values.
+                  <a class="link" href="https://github.com/hay-kot/homebox/issues/236" target="_blank">
+                    See Github Issue #236 for more details
+                  </a>
+                </p>
+              </div>
+              <BaseButton class="btn-primary mt-auto" @click="resetItemDateTimes"> Zero Item Date Times </BaseButton>
             </div>
           </div>
         </template>


### PR DESCRIPTION
New Action to _hopefully_ resolve issue described in 

- #236 
- https://github.com/hay-kot/homebox/issues/236#issuecomment-1408125626

Times were previously being saved with Date _and_ time data, this function resets all the time data and only keeps the date values. This should hopefully resolve the issues of dates being different between the frontend and the backend for some users. 

Also fixes some API documentation and the zero values from showing up in the date field

![CleanShot 2023-02-08 at 17 32 10@2x](https://user-images.githubusercontent.com/64056131/217702660-4605d67f-cab9-48d0-88ed-7932a7ef032f.png)
