### PR TITLE
feat/fix: search location selectors

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -6,3 +6,21 @@
     text-transform: none !important;
 }
 
+/* transparent subtle scrollbar */
+::-webkit-scrollbar {
+  width: 0.2em;
+  background-color: #F5F5F5;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(0,0,0,.2);
+}
+
+::-webkit-scrollbar-track {
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
+  background-color: #F5F5F5;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: #9B9B9B;
+}

--- a/frontend/components/Form/Autocomplete2.vue
+++ b/frontend/components/Form/Autocomplete2.vue
@@ -1,0 +1,157 @@
+<template>
+  <div>
+    <Combobox v-model="value">
+      <ComboboxLabel class="label">
+        <span class="label-text">{{ label }}</span>
+      </ComboboxLabel>
+      <div class="relative">
+        <ComboboxInput
+          :display-value="i => extractDisplay(i as SupportValues)"
+          class="w-full input input-bordered"
+          @change="search = $event.target.value"
+        />
+        <ComboboxButton class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-none">
+          <Icon name="mdi-chevron-down" class="w-5 h-5" />
+        </ComboboxButton>
+        <ComboboxOptions
+          v-if="computedItems.length > 0"
+          class="absolute dropdown-content z-10 mt-2 max-h-60 w-full overflow-auto rounded-md card bg-base-100 border border-gray-400"
+        >
+          <ComboboxOption
+            v-for="item in computedItems"
+            :key="item.id"
+            v-slot="{ active, selected }"
+            :value="item.value"
+            as="template"
+          >
+            <li
+              :class="[
+                'relative cursor-default select-none py-2 pl-3 pr-9 duration-75 ease-in-out transition-colors',
+                active ? 'bg-primary text-white' : 'text-gray-900',
+              ]"
+            >
+              <slot name="display" v-bind="{ item: item, selected, active }">
+                <span :class="['block truncate', selected && 'font-semibold']">
+                  {{ item.display }}
+                </span>
+                <span
+                  v-if="selected"
+                  :class="[
+                    'absolute inset-y-0 right-0 flex text-primary items-center pr-4',
+                    active ? 'text-primary-content' : 'bg-primary',
+                  ]"
+                >
+                  <Icon name="mdi-check" class="h-5 w-5" aria-hidden="true" />
+                </span>
+              </slot>
+            </li>
+          </ComboboxOption>
+        </ComboboxOptions>
+      </div>
+    </Combobox>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import {
+    Combobox,
+    ComboboxInput,
+    ComboboxOptions,
+    ComboboxOption,
+    ComboboxButton,
+    ComboboxLabel,
+  } from "@headlessui/vue";
+
+  type SupportValues = string | { [key: string]: any };
+
+  type ComboItem = {
+    display: string;
+    value: SupportValues;
+    id: number;
+  };
+
+  type Props = {
+    label: string;
+    modelValue: SupportValues | null | undefined;
+    items: string[] | object[];
+    display?: string;
+    multiple?: boolean;
+  };
+
+  const emit = defineEmits(["update:modelValue", "update:search"]);
+  const props = withDefaults(defineProps<Props>(), {
+    label: "",
+    modelValue: "",
+    display: "text",
+    multiple: false,
+  });
+
+  const search = ref("");
+  const value = useVModel(props, "modelValue", emit);
+
+  function extractDisplay(item?: SupportValues): string {
+    if (!item) {
+      return "";
+    }
+
+    if (typeof item === "string") {
+      return item;
+    }
+
+    if (props.display in item) {
+      return item[props.display] as string;
+    }
+
+    // Try these options as well
+    const fallback = ["name", "title", "display", "value"];
+    for (let i = 0; i < fallback.length; i++) {
+      const key = fallback[i];
+      if (key in item) {
+        return item[key] as string;
+      }
+    }
+
+    return "";
+  }
+
+  const computedItems = computed<ComboItem[]>(() => {
+    const list: ComboItem[] = [];
+
+    for (let i = 0; i < props.items.length; i++) {
+      const item = props.items[i];
+
+      const out: Partial<ComboItem> = {
+        id: i,
+        value: item,
+      };
+
+      switch (typeof item) {
+        case "string":
+          out.display = item;
+          break;
+        case "object":
+          // @ts-ignore - up to the user to provide a valid display key
+          out.display = item[props.display] as string;
+          break;
+        default:
+          out.display = "";
+          break;
+      }
+
+      if (search.value && out.display) {
+        const foldSearch = search.value.toLowerCase();
+        const foldDisplay = out.display.toLowerCase();
+
+        if (foldDisplay.startsWith(foldSearch)) {
+          list.push(out as ComboItem);
+        }
+
+        continue;
+      }
+
+      list.push(out as ComboItem);
+    }
+
+    return list;
+  });
+</script>

--- a/frontend/components/Location/Selector.vue
+++ b/frontend/components/Location/Selector.vue
@@ -1,37 +1,43 @@
 <template>
-  <FormAutocomplete
-    v-model="value"
-    v-model:search="form.search"
-    :items="locations"
-    item-text="display"
-    item-value="id"
-    item-search="name"
-    label="Parent Location"
-  >
-    <template #display="{ item }">
+  <FormAutocomplete2 v-if="locations" v-model="value" :items="locations" display="name" label="Parent Location">
+    <template #display="{ item, selected, active }">
       <div>
-        <div>
-          {{ item.name }}
+        <div class="flex w-full">
+          {{ cast(item.value).name }}
+          <span
+            v-if="selected"
+            :class="['absolute inset-y-0 right-0 flex  items-center pr-4', active ? 'text-white' : 'text-primary']"
+          >
+            <Icon name="mdi-check" class="h-5 w-5" aria-hidden="true" />
+          </span>
         </div>
-        <div v-if="item.name != item.display" class="text-xs mt-1">{{ item.display }}</div>
+        <div v-if="cast(item.value).name != cast(item.value).treeString" class="text-xs mt-1">
+          {{ cast(item.value).treeString }}
+        </div>
       </div>
     </template>
-  </FormAutocomplete>
+  </FormAutocomplete2>
 </template>
 
 <script lang="ts" setup>
+  import { FlatTreeItem, useFlatLocations } from "~~/composables/use-location-helpers";
   import { LocationSummary } from "~~/lib/api/types/data-contracts";
 
   type Props = {
     modelValue?: LocationSummary | null;
   };
 
-  const props = defineProps<Props>();
+  // Cast the type of the item to a FlatTreeItem so we can get type "safety" in the template
+  // Note that this does not actually change the type of the item, it just tells the compiler
+  // that the type is FlatTreeItem. We must keep this in sync with the type of the items
+  function cast(value: any): FlatTreeItem {
+    return value as FlatTreeItem;
+  }
 
+  const props = defineProps<Props>();
   const value = useVModel(props, "modelValue");
 
   const locations = await useFlatLocations();
-
   const form = ref({
     parent: null as LocationSummary | null,
     search: "",

--- a/frontend/components/Search/Filter.vue
+++ b/frontend/components/Search/Filter.vue
@@ -1,0 +1,104 @@
+<template>
+  <div ref="el" class="dropdown" :class="{ 'dropdown-open': dropdownOpen }">
+    <button ref="btn" tabindex="0" class="btn btn-xs" @click="toggle">
+      {{ label }} {{ len }} <Icon name="mdi-chevron-down" class="h-4 w-4" />
+    </button>
+    <div tabindex="0" class="dropdown-content mt-1 w-64 shadow bg-base-100 rounded-md">
+      <div class="pt-4 px-4 shadow-sm mb-1">
+        <input v-model="search" type="text" placeholder="Search…" class="input input-sm input-bordered w-full mb-2" />
+      </div>
+      <div class="overflow-y-auto max-h-72 divide-y">
+        <label
+          v-for="v in selectedView"
+          :key="v"
+          class="cursor-pointer px-4 label flex justify-between hover:bg-base-200"
+        >
+          <span class="label-text mr-2">
+            <slot name="display" v-bind="{ item: v }">
+              {{ v[display] }}
+            </slot>
+          </span>
+          <input v-model="selected" type="checkbox" :value="v" class="checkbox checkbox-sm checkbox-primary" />
+        </label>
+        <hr v-if="selected.length > 0" />
+        <label
+          v-for="v in unselected"
+          :key="v"
+          class="cursor-pointer px-4 label flex justify-between hover:bg-base-200"
+        >
+          <span class="label-text mr-2">
+            <slot name="display" v-bind="{ item: v }">
+              {{ v[display] }}
+            </slot>
+          </span>
+          <input v-model="selected" type="checkbox" :value="v" class="checkbox checkbox-sm checkbox-primary" />
+        </label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  type Props = {
+    label: string;
+    options: any[];
+    display?: string;
+    modelValue: any[];
+  };
+
+  const btn = ref<HTMLButtonElement>();
+
+  const search = ref("");
+  const searchFold = computed(() => search.value.toLowerCase());
+  const dropdownOpen = ref(false);
+  const el = ref();
+
+  function toggle() {
+    dropdownOpen.value = !dropdownOpen.value;
+
+    if (!dropdownOpen.value) {
+      btn.value?.blur();
+    }
+  }
+
+  onClickOutside(el, () => {
+    dropdownOpen.value = false;
+  });
+
+  watch(dropdownOpen, val => {
+    console.log(val);
+  });
+
+  const emit = defineEmits(["update:modelValue"]);
+  const props = withDefaults(defineProps<Props>(), {
+    label: "",
+    display: "name",
+    modelValue: () => [],
+  });
+
+  const len = computed(() => {
+    return selected.value.length > 0 ? `(${selected.value.length})` : "";
+  });
+
+  const selectedView = computed(() => {
+    return selected.value.filter(o => {
+      if (searchFold.value.length > 0) {
+        return o[props.display].toLowerCase().includes(searchFold.value);
+      }
+      return true;
+    });
+  });
+
+  const selected = useVModel(props, "modelValue", emit);
+
+  const unselected = computed(() => {
+    return props.options.filter(o => {
+      if (searchFold.value.length > 0) {
+        return o[props.display].toLowerCase().includes(searchFold.value) && !selected.value.includes(o);
+      }
+      return !selected.value.includes(o);
+    });
+  });
+</script>
+
+<style scoped></style>

--- a/frontend/composables/use-location-helpers.ts
+++ b/frontend/composables/use-location-helpers.ts
@@ -4,7 +4,7 @@ import { TreeItem } from "~~/lib/api/types/data-contracts";
 export interface FlatTreeItem {
   id: string;
   name: string;
-  display: string;
+  treeString: string;
 }
 
 export function flatTree(tree: TreeItem[]): Ref<FlatTreeItem[]> {
@@ -18,7 +18,7 @@ export function flatTree(tree: TreeItem[]): Ref<FlatTreeItem[]> {
       v.value.push({
         id: item.id,
         name: item.name,
-        display: display + item.name,
+        treeString: display + item.name,
       });
       if (item.children) {
         flatten(item.children, display + item.name + " > ");

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -17,7 +17,7 @@ export interface DocumentOut {
 }
 
 export interface Group {
-  createdAt: Date;
+  createdAt: string;
   currency: string;
   id: string;
   name: string;
@@ -39,7 +39,7 @@ export interface GroupUpdate {
 }
 
 export interface ItemAttachment {
-  createdAt: Date;
+  createdAt: string;
   document: DocumentOut;
   id: string;
   type: string;
@@ -76,7 +76,7 @@ export interface ItemOut {
   assetId: string;
   attachments: ItemAttachment[];
   children: ItemSummary[];
-  createdAt: Date;
+  createdAt: string;
   description: string;
   fields: ItemField[];
   id: string;
@@ -112,7 +112,7 @@ export interface ItemOut {
 
 export interface ItemSummary {
   archived: boolean;
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   insured: boolean;
@@ -169,7 +169,7 @@ export interface LabelCreate {
 }
 
 export interface LabelOut {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   items: ItemSummary[];
@@ -178,7 +178,7 @@ export interface LabelOut {
 }
 
 export interface LabelSummary {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   name: string;
@@ -193,7 +193,7 @@ export interface LocationCreate {
 
 export interface LocationOut {
   children: LocationSummary[];
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   items: ItemSummary[];
@@ -203,7 +203,7 @@ export interface LocationOut {
 }
 
 export interface LocationOutCount {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   itemCount: number;
@@ -212,7 +212,7 @@ export interface LocationOutCount {
 }
 
 export interface LocationSummary {
-  createdAt: Date;
+  createdAt: string;
   description: string;
   id: string;
   name: string;
@@ -229,7 +229,7 @@ export interface LocationUpdate {
 export interface MaintenanceEntry {
   /** @example "0" */
   cost: string;
-  date: string;
+  date: Date;
   description: string;
   id: string;
   name: string;
@@ -238,7 +238,7 @@ export interface MaintenanceEntry {
 export interface MaintenanceEntryCreate {
   /** @example "0" */
   cost: string;
-  date: string;
+  date: Date;
   description: string;
   name: string;
 }
@@ -246,7 +246,7 @@ export interface MaintenanceEntryCreate {
 export interface MaintenanceEntryUpdate {
   /** @example "0" */
   cost: string;
-  date: string;
+  date: Date;
   description: string;
   name: string;
 }
@@ -258,7 +258,7 @@ export interface MaintenanceLog {
   itemId: string;
 }
 
-export interface PaginationResultItemSummary {
+export interface PaginationResultRepoItemSummary {
   items: ItemSummary[];
   page: number;
   pageSize: number;
@@ -302,7 +302,7 @@ export interface ValueOverTime {
 }
 
 export interface ValueOverTimeEntry {
-  date: string;
+  date: Date;
   name: string;
   value: number;
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "vitest": "^0.28.0"
   },
   "dependencies": {
+    "@headlessui/vue": "^1.7.9",
     "@iconify/vue": "^3.2.1",
     "@nuxtjs/tailwindcss": "^6.1.3",
     "@pinia/nuxt": "^0.4.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@faker-js/faker': ^7.5.0
+  '@headlessui/vue': ^1.7.9
   '@iconify/vue': ^3.2.1
   '@nuxtjs/eslint-config-typescript': ^12.0.0
   '@nuxtjs/tailwindcss': ^6.1.3
@@ -36,6 +37,7 @@ specifiers:
   vue-router: '4'
 
 dependencies:
+  '@headlessui/vue': 1.7.9_vue@3.2.45
   '@iconify/vue': 3.2.1_vue@3.2.45
   '@nuxtjs/tailwindcss': 6.1.3
   '@pinia/nuxt': 0.4.6_prq2uz4lho2pwp6irk4cfkrxwu
@@ -735,6 +737,15 @@ packages:
     resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
     engines: {node: '>=14.0.0', npm: '>=6.0.0'}
     dev: true
+
+  /@headlessui/vue/1.7.9_vue@3.2.45:
+    resolution: {integrity: sha512-vgLBKszj+m2ozaPOnjWMGnspoLJcU/06vygdEAyAS4nDjp72yA7AYbOIEgdaspUhaMs585ApyiSm3jPTuIxAzg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      vue: ^3.2.0
+    dependencies:
+      vue: 3.2.45
+    dev: false
 
   /@humanwhocodes/config-array/0.11.7:
     resolution: {integrity: sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==}


### PR DESCRIPTION
Closes #255 

Reworks search UI to support nested location selection and cleanups up the UI quite a bit. Also fixes a search bug where Location/Label/Field queries were not applied in an expected way. 

Now item results must have 1 of the locations, one of the labels, and one of the fields. Before only one of any of the criteria would need to have been met.

![CleanShot 2023-02-09 at 17 33 01](https://user-images.githubusercontent.com/64056131/217985639-14f3f89c-af5c-42e0-85e7-f07b4b7c2ef0.png)

![CleanShot 2023-02-09 at 17 33 11](https://user-images.githubusercontent.com/64056131/217985662-19da3152-4d96-4345-8c26-ba39ae12dfe9.png)
