### PR TITLE
Fix the docker run command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@
 [Configuration & Docker Compose](https://hay-kot.github.io/homebox/quick-start)
 
 ```bash
-docker run --name=homebox \
-    --restart=always \
-    --publish=3100:7745 \
-    ghcr.io/hay-kot/homebox:latest
+docker run -d \
+  --name homebox \
+  --restart unless-stopped \
+  -p 3100:7745 \
+  -e TZ=Europe/Bucharest \
+  -v ${HOME}/.homebox:/data \
+  ghcr.io/hay-kot/homebox:latest
 ```
 
 ## Credits


### PR DESCRIPTION
## What type of PR is this?
- cleanup
- documentation

## What this PR does / why we need it:

Include volume mounting, time zone, `-d` and better formatting in the README.md

## Which issue(s) this PR fixes:
none

## Release Notes
```release-note
Updated README.md to include a more complete `docker run` command
```