### PR TITLE
build(docker): add image source label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY --from=builder /go/bin/api /app
 RUN chmod +x /app/api
 
 LABEL Name=homebox Version=0.0.1
+LABEL org.opencontainers.image.source="https://github.com/hay-kot/homebox"
 EXPOSE 7745
 WORKDIR /app
 VOLUME [ "/data" ]


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- documentation (ish)

## What this PR does / why we need it:

This adds the `org.opencontainers.image.source` label to the Dockerfile (and thus docker image) pointing to this repository for cross-referencing information. 


## Which issue(s) this PR fixes:

None documented.

## Special notes for your reviewer:

This is purely a label for other tooling to reference, as noted here: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md

## Testing

I have not personally tested this change as it is just adding a label.

## Release Notes

```release-note
NONE
```