### PR TITLE
Low-Privileged and Distroless Docker Image

### DIFF
--- a/.github/workflows/partial-publish.yaml
+++ b/.github/workflows/partial-publish.yaml
@@ -64,3 +64,16 @@ jobs:
             --build-arg COMMIT=$(git rev-parse HEAD) \
             --build-arg BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --platform linux/amd64,linux/arm64,linux/arm/v7 .
+
+      - name: build release tagged the rootless image
+        if: ${{ inputs.release == true }}
+        run: |
+          docker build --push --no-cache \
+            --tag ghcr.io/hay-kot/homebox:nightly-rootless \
+            --tag ghcr.io/hay-kot/homebox:latest-rootless \
+            --tag ghcr.io/hay-kot/homebox:${{ inputs.tag }}-rootless \
+            --build-arg VERSION=${{ inputs.tag }} \
+            --build-arg COMMIT=$(git rev-parse HEAD) \
+            --build-arg BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+            --platform linux/amd64,linux/arm64,linux/arm/v7  \
+            --file Dockerfile.rootless .

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,20 +25,31 @@ COPY --from=frontend-builder /app/.output/public ./app/api/static/public
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-s -w -X main.commit=$COMMIT -X main.buildTime=$BUILD_TIME -X main.version=$VERSION"  \
     -o /go/bin/api \
-    -v ./app/api/*.go
+    -v ./app/api/*.go && \
+    chmod +x /go/bin/api && \
+    mkdir /data
 
 # Production Stage
-FROM alpine:latest
+FROM gcr.io/distroless/static
 
 ENV HBOX_MODE=production
 ENV HBOX_STORAGE_DATA=/data/
 ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_fk=1
+<<<<<<< HEAD
 
 RUN apk --no-cache add ca-certificates
 RUN mkdir /app
 COPY --from=builder /go/bin/api /app
 
 RUN chmod +x /app/api
+=======
+ENV USER=appuser
+ENV UID=1001
+ENV GID=1001
+
+COPY --from=builder --chown=nonroot /go/bin/api /app/api
+COPY --from=builder --chown=nonroot /data /data
+>>>>>>> bc9d021... feat: use distroless image and non-root user
 
 LABEL Name=homebox Version=0.0.1
 LABEL org.opencontainers.image.source="https://github.com/hay-kot/homebox"
@@ -46,5 +57,9 @@ EXPOSE 7745
 WORKDIR /app
 VOLUME [ "/data" ]
 
+<<<<<<< HEAD
+=======
+USER nonroot
+>>>>>>> bc9d021... feat: use distroless image and non-root user
 ENTRYPOINT [ "/app/api" ]
 CMD [ "/data/config.yml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -o /go/bin/api \
     -v ./app/api/*.go && \
     chmod +x /go/bin/api && \
+    # create a directory so that we can copy it in the next stage
     mkdir /data
 
 # Production Stage
@@ -36,6 +37,8 @@ ENV HBOX_MODE=production
 ENV HBOX_STORAGE_DATA=/data/
 ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_fk=1
 
+# Copy the binary and the (empty) /data dir and
+# change the ownership to the low-privileged user
 COPY --from=builder --chown=nonroot /go/bin/api /app/api
 COPY --from=builder --chown=nonroot /data /data
 
@@ -45,6 +48,7 @@ EXPOSE 7745
 WORKDIR /app
 VOLUME [ "/data" ]
 
+# Drop root and run as low-privileged user
 USER nonroot
 ENTRYPOINT [ "/app/api" ]
 CMD [ "/data/config.yml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,21 +35,9 @@ FROM gcr.io/distroless/static
 ENV HBOX_MODE=production
 ENV HBOX_STORAGE_DATA=/data/
 ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_fk=1
-<<<<<<< HEAD
-
-RUN apk --no-cache add ca-certificates
-RUN mkdir /app
-COPY --from=builder /go/bin/api /app
-
-RUN chmod +x /app/api
-=======
-ENV USER=appuser
-ENV UID=1001
-ENV GID=1001
 
 COPY --from=builder --chown=nonroot /go/bin/api /app/api
 COPY --from=builder --chown=nonroot /data /data
->>>>>>> bc9d021... feat: use distroless image and non-root user
 
 LABEL Name=homebox Version=0.0.1
 LABEL org.opencontainers.image.source="https://github.com/hay-kot/homebox"
@@ -57,9 +45,6 @@ EXPOSE 7745
 WORKDIR /app
 VOLUME [ "/data" ]
 
-<<<<<<< HEAD
-=======
 USER nonroot
->>>>>>> bc9d021... feat: use distroless image and non-root user
 ENTRYPOINT [ "/app/api" ]
 CMD [ "/data/config.yml" ]

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -25,26 +25,29 @@ COPY --from=frontend-builder /app/.output/public ./app/api/static/public
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-s -w -X main.commit=$COMMIT -X main.buildTime=$BUILD_TIME -X main.version=$VERSION"  \
     -o /go/bin/api \
-    -v ./app/api/*.go
+    -v ./app/api/*.go && \
+    chmod +x /go/bin/api && \
+    # create a directory so that we can copy it in the next stage
+    mkdir /data
 
 # Production Stage
-FROM alpine:latest
+FROM gcr.io/distroless/static
 
 ENV HBOX_MODE=production
 ENV HBOX_STORAGE_DATA=/data/
 ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_fk=1
 
-RUN apk --no-cache add ca-certificates
-RUN mkdir /app
-COPY --from=builder /go/bin/api /app
-
-RUN chmod +x /app/api
+# Copy the binary and the (empty) /data dir and
+# change the ownership to the low-privileged user
+COPY --from=builder --chown=nonroot /go/bin/api /app
+COPY --from=builder --chown=nonroot /data /data
 
 LABEL Name=homebox Version=0.0.1
 LABEL org.opencontainers.image.source="https://github.com/hay-kot/homebox"
 EXPOSE 7745
-WORKDIR /app
 VOLUME [ "/data" ]
 
-ENTRYPOINT [ "/app/api" ]
+# Drop root and run as low-privileged user
+USER nonroot
+ENTRYPOINT [ "/app" ]
 CMD [ "/data/config.yml" ]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 [Configuration & Docker Compose](https://hay-kot.github.io/homebox/quick-start)
 
 ```bash
+# Ensure data folder has correct permissions
+mkdir -p /path/to/data/folder
+chown 65532:65532 -R /path/to/data/folder
 docker run -d \
   --name homebox \
   --restart unless-stopped \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 [Configuration & Docker Compose](https://hay-kot.github.io/homebox/quick-start)
 
 ```bash
-# Ensure data folder has correct permissions
+# If using the rootless image, ensure data 
+# folder has correct permissions
 mkdir -p /path/to/data/folder
 chown 65532:65532 -R /path/to/data/folder
 docker run -d \
@@ -26,6 +27,7 @@ docker run -d \
   --env TZ=Europe/Bucharest \
   --volume /path/to/data/folder/:/data \
   ghcr.io/hay-kot/homebox:latest
+# ghcr.io/hay-kot/homebox:latest-rootless
 ```
 
 ## Credits

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -5,7 +5,10 @@
 Great for testing out the application, but not recommended for stable use. Checkout the docker-compose for the recommended deployment.
 
 ```sh
-docker run -d \
+# Ensure data folder has correct permissions
+$ mkdir -p /path/to/data/folder
+$ chown 65532:65532 -R /path/to/data/folder
+$ docker run -d \
   --name homebox \
   --restart unless-stopped \
   --publish 3100:7745 \
@@ -37,6 +40,9 @@ volumes:
    homebox-data:
      driver: local
 ```
+
+!!! note
+    If instead of using named volumes you would prefer using a hostMount directly (e.g., `volumes: [ /path/to/data/folder:/data ]`) you need to `chown` the chosen directory in advance to the `65532` user (as shown in the Docker example above).
 
 ## Env Variables & Configuration
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -4,10 +4,15 @@
 
 Great for testing out the application, but not recommended for stable use. Checkout the docker-compose for the recommended deployment.
 
+For each image there are two tags, respectively the regular tag and $TAG-rootless, which uses a non-root image.
+
 ```sh
-# Ensure data folder has correct permissions
+# If using the rootless image, ensure data 
+# folder has correct permissions
 $ mkdir -p /path/to/data/folder
 $ chown 65532:65532 -R /path/to/data/folder
+# ---------------------------------------
+# Run the image
 $ docker run -d \
   --name homebox \
   --restart unless-stopped \
@@ -15,6 +20,8 @@ $ docker run -d \
   --env TZ=Europe/Bucharest \
   --volume /path/to/data/folder/:/data \
   ghcr.io/hay-kot/homebox:latest
+# ghcr.io/hay-kot/homebox:latest-rootless
+ 
 ```
 
 ## Docker-Compose
@@ -25,6 +32,7 @@ version: "3.4"
 services:
   homebox:
     image: ghcr.io/hay-kot/homebox:latest
+#   image: ghcr.io/hay-kot/homebox:latest-rootless
     container_name: homebox
     restart: always
     environment:
@@ -42,7 +50,7 @@ volumes:
 ```
 
 !!! note
-    If instead of using named volumes you would prefer using a hostMount directly (e.g., `volumes: [ /path/to/data/folder:/data ]`) you need to `chown` the chosen directory in advance to the `65532` user (as shown in the Docker example above).
+    If you use the `rootless` image, and instead of using named volumes you would prefer using a hostMount directly (e.g., `volumes: [ /path/to/data/folder:/data ]`) you need to `chown` the chosen directory in advance to the `65532` user (as shown in the Docker example above).
 
 ## Env Variables & Configuration
 


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR attempts to accomplish the following:

* Minimize the image size
* Minimize the attack surface for the application (distroless images will not include `busybox` or a shell in general)
* Avoid running the application as `root` as it's not required. In fact, since the application requires some persistence, and in most cases users will achieve this with a Docker volume mount (or Kubernetes hostMount), running as `root` introduces significant risk of container breakout.


## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

I have tested the image locally without issues. However, I did not figure out (yet) how to test the trigger of emails. The only concern I have is that if the application requires `openssl` library to work, then `distroless:static` won't be sufficient, and `distroless:base` should be used instead.

However, based on the fact that `CGO_ENABLED=0` is set, there shouldn't be the need for any C library.

## Testing

_(fill-in or delete this section)_

I have locally built and run the image.

```
$ docker build -t homebox .
# yay! 1.2 MB saved :)
$ docker images | grep homebox
homebox                                latest           87a46cf73a3a   14 minutes ago      37.6MB
ghcr.io/hay-kot/homebox                latest            b973f70d7d21   5 weeks ago    38.8MB
$ docker run --name=homebox -p 3100:7745 --rm homebox:latest
9:28AM INF ../go/src/app/app/api/main.go:152 > Starting HTTP Server on :7745
9:28AM INF ../go/src/app/internal/web/mid/logger.go:25 > request received method=GET path=/ rid=000b2e0d2e1d/XRswUPXnVb-000001
9:28AM INF ../go/src/app/internal/web/mid/logger.go:30 > request finished method=GET path=/ rid=000b2e0d2e1d/XRswUPXnVb-000001 status=0
```


## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
* Change base image to distroless and non-root
```