### PR TITLE
update go version in devcontainer to 1.20 to match version in go.mod

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,6 +35,6 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
 	"features": {
-		"golang": "1.19"
+		"golang": "1.20"
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

I noticed that the devcontainer setup threw an error about tiny not supporting go 1.19, so I tried to figure out the problem. It turned out that in the devcontainer.json go 1.19 was requested while in the go.mod file already go 1.20 was used.

