### PR TITLE
Fixed 3 places where API URLs were not constructed by function route

### DIFF
--- a/frontend/components/global/PageQRCode.vue
+++ b/frontend/components/global/PageQRCode.vue
@@ -15,10 +15,12 @@
 </template>
 
 <script setup lang="ts">
+  import { route } from "../../lib/api/base";
+
   function getQRCodeUrl(): string {
     const currentURL = window.location.href;
 
-    return `/api/v1/qrcode?data=${encodeURIComponent(currentURL)}`;
+    return route(`/qrcode`, { 'data': encodeURIComponent(currentURL) });
   }
 </script>
 

--- a/frontend/components/global/PageQRCode.vue
+++ b/frontend/components/global/PageQRCode.vue
@@ -20,7 +20,7 @@
   function getQRCodeUrl(): string {
     const currentURL = window.location.href;
 
-    return route(`/qrcode`, { 'data': encodeURIComponent(currentURL) });
+    return route(`/qrcode`, { data: encodeURIComponent(currentURL) });
   }
 </script>
 

--- a/frontend/lib/api/base/base-api.ts
+++ b/frontend/lib/api/base/base-api.ts
@@ -76,7 +76,7 @@ export class BaseAPI {
   // URL already has a query param, this will not work.
   authURL(url: string): string {
     if (this.attachmentToken) {
-      return route(url, { 'access_token': this.attachmentToken });
+      return route(url, { access_token: this.attachmentToken });
     }
     return url;
   }

--- a/frontend/lib/api/base/base-api.ts
+++ b/frontend/lib/api/base/base-api.ts
@@ -1,4 +1,5 @@
 import { Requests } from "../../requests";
+import { route } from ".";
 
 const ZERO_DATE = "0001-01-01T00:00:00Z";
 
@@ -70,12 +71,12 @@ export class BaseAPI {
     this.attachmentToken = attachmentToken;
   }
 
-  // if a attachmentToken is present it will be added to URL as a query param
+  // if an attachmentToken is present, it will be added to URL as a query param
   // this is done with a simple appending of the query param to the URL. If your
   // URL already has a query param, this will not work.
   authURL(url: string): string {
     if (this.attachmentToken) {
-      return `/api/v1${url}?access_token=${this.attachmentToken}`;
+      return route(url, { 'access_token': this.attachmentToken });
     }
     return url;
   }

--- a/frontend/lib/api/base/urls.ts
+++ b/frontend/lib/api/base/urls.ts
@@ -11,13 +11,13 @@ export function overrideParts(host: string, prefix: string) {
 export type QueryValue = string | string[] | number | number[] | boolean | null | undefined;
 
 /**
- * route is a the main URL builder for the API. It will use a predefined host and prefix (global)
- * in the urls.ts file and then append the passed in path parameter uring the `URL` class from the
+ * route is the main URL builder for the API. It will use a predefined host and prefix (global)
+ * in the urls.ts file and then append the passed-in path parameter using the `URL` class from the
  * browser. It will also append any query parameters passed in as the second parameter.
  *
  * The default host `http://localhost.com` is removed from the path if it is present. This allows us
  * to bootstrap the API with different hosts as needed (like for testing) but still allows us to use
- * relative URLs in pruduction because the API and client bundle are served from the same server/host.
+ * relative URLs in production because the API and client bundle are served from the same server/host.
  */
 export function route(rest: string, params: Record<string, QueryValue> = {}): string {
   const url = new URL(parts.prefix + rest, parts.host);

--- a/frontend/pages/reports/label-generator.vue
+++ b/frontend/pages/reports/label-generator.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { route } from "../../lib/api/base";
+
   definePageMeta({
     middleware: ["auth"],
     layout: false,
@@ -176,7 +178,7 @@
 
     const data = `${origin}/a/${assetID}`;
 
-    return `/api/v1/qrcode?data=${encodeURIComponent(data)}`;
+    return route(`/qrcode`, { 'data': encodeURIComponent(data) });
   }
 
   function getItem(n: number): LabelData {

--- a/frontend/pages/reports/label-generator.vue
+++ b/frontend/pages/reports/label-generator.vue
@@ -178,7 +178,7 @@
 
     const data = `${origin}/a/${assetID}`;
 
-    return route(`/qrcode`, { 'data': encodeURIComponent(data) });
+    return route(`/qrcode`, { data: encodeURIComponent(data) });
   }
 
   function getItem(n: number): LabelData {


### PR DESCRIPTION
## What type of PR is this?
- Fix

## What this PR does / why we need it:
- When assembling a URL to connect to the API, the route function has to be called. This way, there is only one place where API host and API prefix are written in the code.
- A few typos were corrected.

## Testing
- I checked that the API server was correctly responding when setting a different host name, specifically for the 3 places where I changed the URL construction (label generator, QR code and attachments).

## Release Notes
```
API host can now be changed at a single place: frontend/lib/api/base/urls.ts
```