### PR TITLE
Added parseDependency to swag

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,7 +20,7 @@ tasks:
       - db:generate
     cmds:
       - cd backend/app/api/static && swag fmt --dir=../
-      - cd backend/app/api/static && swag init --dir=../,../../../internal,../../../pkgs
+      - cd backend/app/api/static && swag init --dir=../,../../../internal,../../../pkgs --parseDependency
       - |
         npx swagger-typescript-api \
           --no-client \

--- a/backend/app/api/handlers/v1/v1_ctrl_items_attachments.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items_attachments.go
@@ -29,7 +29,7 @@ type (
 //	@Param    type formData string true "Type of file"
 //	@Param    name formData string true "name of the file including extension"
 //	@Success  200  {object} repo.ItemOut
-//	@Failure  422  {object} mid.ErrorResponse
+//	@Failure  422  {object} validate.ErrorResponse
 //	@Router   /v1/items/{id}/attachments [POST]
 //	@Security Bearer
 func (ctrl *V1Controller) HandleItemAttachmentCreate() errchain.HandlerFunc {


### PR DESCRIPTION
## What type of PR is this?
- bug
## What this PR does / why we need it:

Currently building the project inside of a devcontainer is impossible. This change fixes the problem with finding model definition by swag.

## Which issue(s) this PR fixes:

Fixes #317 

## Release Notes
```
Generating Swagger definition by swag repaired.
```