### PR TITLE
update "h3" verison to 1.7.1

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2124,7 +2124,7 @@ packages:
       clear-module: 4.1.2
       consola: 2.15.3
       defu: 6.1.1
-      h3: 0.8.6
+      h3: 1.7.1
       postcss: 8.4.19
       postcss-custom-properties: 12.1.11(postcss@8.4.19)
       postcss-nesting: 10.2.0(postcss@8.4.19)
@@ -5230,14 +5230,6 @@ packages:
     dependencies:
       duplexer: 0.1.2
 
-  /h3@0.8.6:
-    resolution: {integrity: sha512-CSWNOKa3QGo67rFU2PhbFTp0uPJtilNji2Z0pMiSRQt3+OkIW0u3E1WMJqIycLqaTgb9JyFqH/S4mcTyyGtvyQ==}
-    dependencies:
-      cookie-es: 0.5.0
-      destr: 1.2.2
-      radix3: 0.2.1
-      ufo: 0.8.6
-    dev: false
 
   /h3@1.7.1:
     resolution: {integrity: sha512-A9V2NEDNHet7v1gCg7CMwerSigLi0SRbhTy7C3lGb0N4YKIpPmLDjedTUopqp4dnn7COHfqUjjaz3zbtz4QduA==}


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?


- bug


## What this PR does / why we need it:
Upgrade the version of the "h3" package to `1.7.1` which was previously `0.8.6` and causing the error due to which build was failing.
 - `pnpm-lock.yaml` file was changed


## Which issue(s) this PR fixes:

Fixes https://github.com/hay-kot/homebox/issues/501

## Release Notes

```release-note 
dependency h3 version updated to 1.7.1
```