### PR TITLE
feat: set cookies' expires attribute and fix remember me

### DIFF
--- a/frontend/composables/use-auth-context.ts
+++ b/frontend/composables/use-auth-context.ts
@@ -114,6 +114,16 @@ class AuthContext implements IAuthContext {
     const r = await api.login(email, password, stayLoggedIn);
 
     if (!r.error) {
+      const expiresAt = new Date(r.data.expiresAt);
+      this._token = useCookie(AuthContext.cookieTokenKey, {
+        expires: expiresAt,
+      });
+      this._expiresAt = useCookie(AuthContext.cookieExpiresAtKey, {
+        expires: expiresAt,
+      });
+      this._attachmentToken = useCookie(AuthContext.cookieAttachmentTokenKey, {
+        expires: expiresAt,
+      });
       this._token.value = r.data.token;
       this._expiresAt.value = r.data.expiresAt as string;
       this._attachmentToken.value = r.data.attachmentToken;


### PR DESCRIPTION
Since modern browsers set cookies' `expires` to 'session' by default (clear these cookies after user close browser), remember me will not work currently.

This PR adds some logic to create cookies with an expiration time from response. Now these cookies will have correct expiration time (will not be deleted after closing browser) .

Remember Me will work correctly after this fixing.

And maybe we don't need to validate cookies' expiration times in frontend (cookies will be deleted by browser after they expire).