### PR TITLE
Added currencies XAG and XAU to currency.ts

### DIFF
--- a/backend/internal/data/ent/group/group.go
+++ b/backend/internal/data/ent/group/group.go
@@ -160,6 +160,8 @@ const (
 	CurrencyThb Currency = "thb"
 	CurrencyTry Currency = "try"
 	CurrencyUsd Currency = "usd"
+	CurrencyXag Currency = "xag"
+	CurrencyXau Currency = "xau"
 	CurrencyZar Currency = "zar"
 )
 
@@ -170,7 +172,7 @@ func (c Currency) String() string {
 // CurrencyValidator is a validator for the "currency" field enum values. It is called by the builders before save.
 func CurrencyValidator(c Currency) error {
 	switch c {
-	case CurrencyAed, CurrencyAud, CurrencyBgn, CurrencyBrl, CurrencyCad, CurrencyChf, CurrencyCny, CurrencyCzk, CurrencyDkk, CurrencyEur, CurrencyGbp, CurrencyHkd, CurrencyIdr, CurrencyInr, CurrencyJpy, CurrencyKrw, CurrencyMxn, CurrencyNok, CurrencyNzd, CurrencyPln, CurrencyRmb, CurrencyRon, CurrencyRub, CurrencySar, CurrencySek, CurrencySgd, CurrencyThb, CurrencyTry, CurrencyUsd, CurrencyZar:
+	case CurrencyAed, CurrencyAud, CurrencyBgn, CurrencyBrl, CurrencyCad, CurrencyChf, CurrencyCny, CurrencyCzk, CurrencyDkk, CurrencyEur, CurrencyGbp, CurrencyHkd, CurrencyIdr, CurrencyInr, CurrencyJpy, CurrencyKrw, CurrencyMxn, CurrencyNok, CurrencyNzd, CurrencyPln, CurrencyRmb, CurrencyRon, CurrencyRub, CurrencySar, CurrencySek, CurrencySgd, CurrencyThb, CurrencyTry, CurrencyUsd, CurrencyXag, CurrencyXau, CurrencyZar:
 		return nil
 	default:
 		return fmt.Errorf("group: invalid enum value for currency field: %q", c)

--- a/backend/internal/data/ent/schema/group.go
+++ b/backend/internal/data/ent/schema/group.go
@@ -58,6 +58,8 @@ func (Group) Fields() []ent.Field {
 				"thb",
 				"try",
 				"usd",
+				"xag",
+				"xau",
 				"zar",
 			),
 	}

--- a/frontend/lib/data/currency.ts
+++ b/frontend/lib/data/currency.ts
@@ -27,6 +27,8 @@ export type Codes =
   | "THB"
   | "TRY"
   | "USD"
+  | "XAG"
+  | "XAU"
   | "ZAR";
 
 export type Currency = {
@@ -65,5 +67,7 @@ export const currencies: Currency[] = [
   { code: "THB", local: "Thailand", symbol: "฿", name: "Thai Baht" },
   { code: "TRY", local: "Turkey", symbol: "₺", name: "Turkish Lira" },
   { code: "USD", local: "United States", symbol: "$", name: "United States Dollar" },
+  { code: "XAG", local: "Global", symbol: "XAG", name: "Silver Troy Ounce" },
+  { code: "XAU", local: "Global", symbol: "XAU", name: "Gold Troy Ounce" },
   { code: "ZAR", local: "South Africa", symbol: "R", name: "South African Rand" },
 ];


### PR DESCRIPTION
I have added the currencies XAG and XAU for those who wish to measure value with something of substance.

Review the ISO 4217 standard to view a full list of official currency codes including the ones I have added.

https://www.iso.org/iso-4217-currency-codes.html
https://en.wikipedia.org/wiki/ISO_4217

Example:
https://www.xe.com/currencyconverter/convert/?Amount=100&From=XAG&To=USD

API for exchange rates:
https://openexchangerates.org/

## What type of PR is this?

- feature

## What this PR does / why we need it:

Adds two currencies to homebox.
We need this feature to serve those who wish to value their inventory with these currencies.

## Which issue(s) this PR fixes:

This fixes the lack of currencies.

## Special notes for your reviewer:

Does it function as expected?

## Testing

I have not tested it.

## Release Notes

Added currencies XAG and XAU.

```release-note
```