### PR TITLE
fix: mobile "Create and Add Another" goes off screen

### DIFF
--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -19,7 +19,7 @@
             <label tabindex="0" class="btn rounded-l-none rounded-r-xl">
               <Icon class="h-5 w-5" name="mdi-chevron-down" />
             </label>
-            <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-64">
+            <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-64 right-0">
               <li>
                 <button type="button" @click="create(false)">Create and Add Another</button>
               </li>

--- a/frontend/components/Label/CreateModal.vue
+++ b/frontend/components/Label/CreateModal.vue
@@ -17,7 +17,7 @@
             <label tabindex="0" class="btn rounded-l-none rounded-r-xl">
               <Icon class="h-5 w-5" name="mdi-chevron-down" />
             </label>
-            <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-64">
+            <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-64 right-0">
               <li>
                 <button type="button" @click="create(false)">Create and Add Another</button>
               </li>

--- a/frontend/components/Location/CreateModal.vue
+++ b/frontend/components/Location/CreateModal.vue
@@ -18,7 +18,7 @@
             <label tabindex="0" class="btn rounded-l-none rounded-r-xl">
               <Icon class="h-5 w-5" name="mdi-chevron-down" />
             </label>
-            <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-64">
+            <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-64 right-0">
               <li>
                 <button type="button" @click="create(false)">Create and Add Another</button>
               </li>


### PR DESCRIPTION
## What type of PR is this?

bug

## What this PR does / why we need it:

"Create and Add Another" goes off screen on mobile/smaller screens:
<img width="403" alt="image" src="https://github.com/hay-kot/homebox/assets/5134923/ac76cc80-d40f-436e-a776-daf7cba78b3d">
<img width="657" alt="image" src="https://github.com/hay-kot/homebox/assets/5134923/484b5af1-7e6e-4c7a-9ea2-1cea777a615d">


This fixes it so that the dropdown is right aligned on mobile/smaller screens, but keeps it left aligned on bigger screens:
<img width="400" alt="image" src="https://github.com/hay-kot/homebox/assets/5134923/c93e49a0-e8e0-4405-8e0b-a8674f43f86d">
<img width="684" alt="image" src="https://github.com/hay-kot/homebox/assets/5134923/5c494fe5-1a76-4537-9cce-bb80aceed75f">
<img width="721" alt="image" src="https://github.com/hay-kot/homebox/assets/5134923/694fb96f-74ad-44f7-bbb7-96d38d756edc">

## Release Notes

```release-note
Make sure the "Create and Add Another" button does not go off the screen on mobile or smaller screen sizes
```