### PR TITLE
Add total price indicator to labels and locations

### DIFF
--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -193,6 +193,7 @@ export interface LabelOut {
   id: string;
   name: string;
   updatedAt: Date | string;
+  totalPrice: number | undefined;
 }
 
 export interface LabelSummary {
@@ -217,6 +218,7 @@ export interface LocationOut {
   name: string;
   parent: LocationSummary;
   updatedAt: Date | string;
+  totalPrice: number | undefined;
 }
 
 export interface LocationOutCount {

--- a/frontend/pages/label/[id].vue
+++ b/frontend/pages/label/[id].vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import Currency from "~~/components/global/Currency.vue";
+
   definePageMeta({
     middleware: ["auth"],
   });
@@ -84,6 +86,8 @@
       return [];
     }
 
+    label.value.totalPrice = resp.data.items.map(item => Number(item.purchasePrice)).reduce((a, b) => a + b, 0);
+
     return resp.data.items;
   });
 </script>
@@ -111,8 +115,17 @@
               </div>
             </div>
             <div>
-              <h1 class="text-2xl pb-1">
+              <h1 class="text-2xl pb-1 flex items-center gap-3">
                 {{ label ? label.name : "" }}
+
+                <div
+                  v-if="label && label.totalPrice"
+                  class="text-xs bg-secondary text-secondary-content rounded-full px-2 py-1"
+                >
+                  <div>
+                    <Currency :amount="label.totalPrice" />
+                  </div>
+                </div>
               </h1>
               <div class="flex gap-1 flex-wrap text-xs">
                 <div>


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

It adds an indicator to the /label and /location pages to show the overall purchase price.

For locations it includes child locations.

#### Location
<img width="996" alt="image" src="https://github.com/hay-kot/homebox/assets/81699395/8e1770aa-6c9b-4fdc-a630-fe5babf270bf">

#### Label
<img width="996" alt="image" src="https://github.com/hay-kot/homebox/assets/81699395/554701bb-6f91-4a4c-8037-81cbe699c164">


Changed files:
- frontend/lib/api/types/data-contracts.ts
  - add optional totalPrice field to LabelOut and LocationOut types
- frontend/pages/label/[id].vue
  - Add total price for label to header
- frontend/pages/location/[id].vue 
  - Add total price for location and child locations
  - Additional request: Request of location tree

## Special notes for your reviewer:

I haven't used typescript before, there's no errors and it works but it might not be done to the best way.

## Testing

Labels
 - Tested with lots, some and no items

Locations
 - Location with/without items
 - With/without child locations
 - With child locations, and without own items

## Release Notes

```release-note
Added a chip-style indicator to show the total price for labels and locations.
```