### PR TITLE
Enable search by serial number or model number

### DIFF
--- a/backend/internal/data/repo/repo_items.go
+++ b/backend/internal/data/repo/repo_items.go
@@ -341,8 +341,10 @@ func (e *ItemsRepository) QueryByGroup(ctx context.Context, gid uuid.UUID, q Ite
 			item.Or(
 				item.NameContainsFold(q.Search),
 				item.DescriptionContainsFold(q.Search),
-				item.NotesContainsFold(q.Search),
+				item.SerialNumberContainsFold(q.Search),
+				item.ModelNumberContainsFold(q.Search),
 				item.ManufacturerContainsFold(q.Search),
+				item.NotesContainsFold(q.Search),
 			),
 		)
 	}


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Extend the existing search functionality to be able to search by serial number or model number.

Searching by item description, manufacturer or notes was already possible by default, so it makes sense to extend the searched fields also to the serial number and model number.

## Release Notes

```release-note
Enable search by serial number or model number
```