### PR TITLE
Render newlines in markdown fields

### DIFF
--- a/frontend/components/global/Markdown.vue
+++ b/frontend/components/global/Markdown.vue
@@ -11,6 +11,7 @@
   });
 
   const md = new MarkdownIt({
+    breaks: true,
     html: true,
     linkify: true,
     typographer: true,


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Newlines are displayed when editing markdown fields, but not when rendering the markdown content. This PR keeps the displayed text consistent between both views.

## Which issue(s) this PR fixes:

Fixes #681

## Release Notes

```release-note
Render newlines in markdown fields
```