### PR TITLE
fix task swag

### DIFF
--- a/backend/app/api/handlers/v1/controller.go
+++ b/backend/app/api/handlers/v1/controller.go
@@ -112,7 +112,7 @@ func NewControllerV1(svc *services.AllServices, repos *repo.AllRepos, bus *event
 //	@Summary Application Info
 //	@Tags    Base
 //	@Produce json
-//	@Success 200 {object} ApiSummary
+//	@Success 200 {object} APISummary
 //	@Router  /v1/status [GET]
 func (ctrl *V1Controller) HandleBase(ready ReadyFunc, build Build) errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
Task swag is failing

```
$ go-task swag -f
task: [swag] swag fmt --dir=../
task: [swag] swag init --dir=../,../../../internal/core/services,../../../internal/data/repo --parseDependency
2024/01/15 12:50:47 Generate swagger docs....
2024/01/15 12:50:47 Generate general API Info, search dir:../
2024/01/15 12:50:47 Generate general API Info, search dir:../../../internal/core/services
2024/01/15 12:50:47 Generate general API Info, search dir:../../../internal/data/repo
2024/01/15 12:50:49 ParseComment error in file /home/quoing/src/homebox/backend/app/api/handlers/v1/controller.go :cannot find type definition: ApiSummary
task: Failed to run task "swag": exit status 1
```

Fixes error above.. seems to be caused by commit: https://github.com/hay-kot/homebox/commit/e8449b3a7363a6cfd5bc6151609e6d2d94b4f7d8