### PR TITLE
backend: Use zerolog level parser, set global log level correctly from configuration

### DIFF
--- a/backend/app/api/logger.go
+++ b/backend/app/api/logger.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 
 	"github.com/hay-kot/homebox/backend/internal/sys/config"
 	"github.com/rs/zerolog"
@@ -18,24 +17,8 @@ func (a *app) setupLogger() {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr}).With().Caller().Logger()
 	}
 
-	log.Level(getLevel(a.conf.Log.Level))
-}
-
-func getLevel(l string) zerolog.Level {
-	switch strings.ToLower(l) {
-	case "debug":
-		return zerolog.DebugLevel
-	case "info":
-		return zerolog.InfoLevel
-	case "warn":
-		return zerolog.WarnLevel
-	case "error":
-		return zerolog.ErrorLevel
-	case "fatal":
-		return zerolog.FatalLevel
-	case "panic":
-		return zerolog.PanicLevel
-	default:
-		return zerolog.InfoLevel
+	level, err := zerolog.ParseLevel(a.conf.Log.Level)
+	if err == nil {
+		zerolog.SetGlobalLevel(level)
 	}
 }


### PR DESCRIPTION


## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

There are two changes here:

* Migrate to use the zerolog-shipped level parser instead of the manual logic.
* Use the correct API for setting the global log level. Note that the `log.Level(...)` creates a *child* logger with the specified level. See: https://pkg.go.dev/github.com/rs/zerolog@v1.31.0/log#Level

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

The `--log-level` flag does not work according to the behavior stated in the documentation.

```bash
$ ./homebox --log-level info
5:06PM INF ../../../../../home/jenkins/workspace/external--homebox/backend/app/api/handlers/v1/v1_ctrl_auth.go:100 > registering auth provider name=local
5:06PM INF ../../../../../home/jenkins/workspace/external--homebox/backend/app/api/main.go:192 > Starting HTTP Server on :7745
```

```bash
$ ./homebox --log-level error
5:06PM INF ../../../../../home/jenkins/workspace/external--homebox/backend/app/api/handlers/v1/v1_ctrl_auth.go:100 > registering auth provider name=local
5:06PM INF ../../../../../home/jenkins/workspace/external--homebox/backend/app/api/main.go:192 > Starting HTTP Server on :7745
```

## Special notes for your reviewer:

_(fill-in or delete this section)_

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

Behavior with this patch:

```bash
$ ./homebox --log-level debug
5:01PM INF app/api/handlers/v1/v1_ctrl_auth.go:100 > registering auth provider name=local
5:01PM INF app/api/main.go:192 > Starting HTTP Server on :7745
```

```bash
$ ./homebox --log-level error
# no startup output
# ...
# force an error
5:01PM ERR internal/web/mid/errors.go:31 > ERROR occurred error="valid authorization token is required" req_id=XAIKOR/9n1V1SgIkd-000001
```

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
NONE
```