### PR TITLE
feat(auth): support for forwarded auth provider

### DIFF
--- a/backend/app/api/providers/forwardauth.go
+++ b/backend/app/api/providers/forwardauth.go
@@ -1,0 +1,36 @@
+package providers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/hay-kot/homebox/backend/internal/core/services"
+	"github.com/hay-kot/homebox/backend/internal/sys/config"
+	"github.com/hay-kot/homebox/backend/pkgs/ipcheck"
+)
+
+type ForwardAuthProvider struct {
+	service    *services.UserService
+	authConfig *config.AuthConfig
+}
+
+func NewForwardAuthProvider(service *services.UserService, authConfig *config.AuthConfig) *ForwardAuthProvider {
+	return &ForwardAuthProvider{
+		service:    service,
+		authConfig: authConfig,
+	}
+}
+
+func (p *ForwardAuthProvider) Name() string {
+	return "forwardauth"
+}
+
+func (p *ForwardAuthProvider) Authenticate(w http.ResponseWriter, r *http.Request) (services.UserAuthTokenDetail, error) {
+	if !ipcheck.ValidateAgainstList(r.RemoteAddr, p.authConfig.ForwardAuthAllowedIps) {
+		return services.UserAuthTokenDetail{}, errors.New("forward authentication denied, IP address not allowed")
+	}
+
+	username := r.Header.Get(p.authConfig.ForwardAuthHeader)
+
+	return p.service.PasswordlessLogin(r.Context(), username, p.authConfig.ForwardAuthAutoRegister)
+}

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -56,6 +56,8 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		v1.WithMaxUploadSize(a.conf.Web.MaxUploadSize),
 		v1.WithRegistration(a.conf.Options.AllowRegistration),
 		v1.WithDemoStatus(a.conf.Demo), // Disable Password Change in Demo Mode
+		v1.WithForwardAuthHeader(a.conf.Auth.ForwardAuthHeader),
+		v1.WithForwardAuthAllowedIps(a.conf.Auth.ForwardAuthAllowedIps),
 	)
 
 	r.Get(v1Base("/status"), chain.ToHandlerFunc(v1Ctrl.HandleBase(func() bool { return true }, v1.Build{
@@ -67,6 +69,7 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 	r.Get(v1Base("/currencies"), chain.ToHandlerFunc(v1Ctrl.HandleCurrency()))
 
 	providers := []v1.AuthProvider{
+		providers.NewForwardAuthProvider(a.services.User, &a.conf.Auth),
 		providers.NewLocalProvider(a.services.User),
 	}
 

--- a/backend/internal/sys/config/conf.go
+++ b/backend/internal/sys/config/conf.go
@@ -20,6 +20,7 @@ type Config struct {
 	conf.Version
 	Mode    string     `yaml:"mode"    conf:"default:development"` // development or production
 	Web     WebConfig  `yaml:"web"`
+	Auth    AuthConfig `yaml:"auth"`
 	Storage Storage    `yaml:"storage"`
 	Log     LoggerConf `yaml:"logger"`
 	Mailer  MailerConf `yaml:"mailer"`
@@ -46,6 +47,12 @@ type WebConfig struct {
 	ReadTimeout   time.Duration `yaml:"read_timeout"    conf:"default:10s"`
 	WriteTimeout  time.Duration `yaml:"write_timeout"   conf:"default:10s"`
 	IdleTimeout   time.Duration `yaml:"idle_timeout"    conf:"default:30s"`
+}
+
+type AuthConfig struct {
+	ForwardAuthHeader       string `yaml:"forward_auth_header"        conf:"default:Remote-Email"`
+	ForwardAuthAllowedIps   string `yaml:"forward_auth_allowed_ips"`
+	ForwardAuthAutoRegister bool   `yaml:"forward_auth_auto_register" conf:"default:false"`
 }
 
 // New parses the CLI/Config file and returns a Config struct. If the file argument is an empty string, the

--- a/backend/pkgs/ipcheck/ipcheck.go
+++ b/backend/pkgs/ipcheck/ipcheck.go
@@ -1,0 +1,37 @@
+// Package ipcheck provides helper functions to validate IP addresses against criteria
+package ipcheck
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+func ValidateAgainstList(ip string, comaSeparatedList string) bool {
+	if comaSeparatedList == "" || ip == "" {
+		return false
+	}
+
+	if net.ParseIP(ip) == nil {
+		ip, _, _ = net.SplitHostPort(ip)
+	}
+
+	if ip == "" {
+		return false
+	}
+
+	cidrs := strings.Split(comaSeparatedList, ",")
+	testedIP, _, err := net.ParseCIDR(fmt.Sprintf("%s/32", ip))
+	if err != nil {
+		return false
+	}
+
+	for _, cidr := range cidrs {
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err == nil && ipnet.Contains(testedIP) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/backend/pkgs/ipcheck/ipcheck_test.go
+++ b/backend/pkgs/ipcheck/ipcheck_test.go
@@ -1,0 +1,54 @@
+package ipcheck
+
+import (
+	"testing"
+)
+
+func Test_ValidateAgainstList(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		list string
+		want bool
+	}{
+		{
+			name: "IPv4 matching the list",
+			ip:   "192.168.1.1",
+			list: "192.168.11.0/24,192.168.1.0/24",
+			want: true,
+		}, {
+			name: "IPv4 with exact match",
+			ip:   "192.168.2.2",
+			list: "192.168.2.2/32,192.168.0.0/24",
+			want: true,
+		}, {
+			name: "IPv4 with no match",
+			ip:   "192.168.3.3",
+			list: "192.168.0.0/24,192.168.2.0/24",
+			want: false,
+		}, {
+			name: "IPv6 matching the list",
+			ip:   "1111:1111:1111:1111:1111:1111:1111:1111",
+			list: "1111:1111:1111:1111::/64,2222:2222:2222:2222::/64",
+			want: true,
+		}, {
+			name: "IPv6 with exact match",
+			ip:   "2222:2222:2222:2222:2222:2222:2222:2222",
+			list: "1111:1111:1111:1111::/64,2222:2222:2222:2222:2222:2222:2222:2222/128",
+			want: true,
+		}, {
+			name: "IPv6 with no match",
+			ip:   "3333:3333:3333:3333:3333:3333:3333:3333",
+			list: "3333:3333:3333:3333:3333:3333:3333:4444/128,4444::/32",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateAgainstList(tt.ip, tt.list); got != tt.want {
+				t.Errorf("ValidateAgainstList() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/docs/api/openapi-2.0.json
+++ b/docs/docs/api/openapi-2.0.json
@@ -2847,6 +2847,9 @@
                 "demo": {
                     "type": "boolean"
                 },
+                "forwardAuthAvailable": {
+                    "type": "boolean"
+                },
                 "health": {
                     "type": "boolean"
                 },

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -54,29 +54,32 @@ volumes:
 
 ## Env Variables & Configuration
 
-| Variable                             | Default                | Description                                                                        |
-| ------------------------------------ | ---------------------- | ---------------------------------------------------------------------------------- |
-| HBOX_MODE                            | production             | application mode used for runtime behavior  can be one of: development, production |
-| HBOX_WEB_PORT                        | 7745                   | port to run the web server on, if you're using docker do not change this           |
-| HBOX_WEB_HOST                        |                        | host to run the web server on, if you're using docker do not change this           |
-| HBOX_OPTIONS_ALLOW_REGISTRATION      | true                   | allow users to register themselves                                                 |
-| HBOX_OPTIONS_AUTO_INCREMENT_ASSET_ID | true                   | auto increments the asset_id field for new items                                   |
-| HBOX_OPTIONS_CURRENCY_CONFIG         |                        | json configuration file containing additional currencie                            |
-| HBOX_WEB_MAX_UPLOAD_SIZE             | 10                     | maximum file upload size supported in MB                                           |
-| HBOX_WEB_READ_TIMEOUT                | 10                     | Read timeout of HTTP sever                                                         |
-| HBOX_WEB_WRITE_TIMEOUT               | 10                     | Write timeout of HTTP server                                                       |
-| HBOX_WEB_IDLE_TIMEOUT                | 30                     | Idle timeout of HTTP server                                                        |
-| HBOX_STORAGE_DATA                    | /data/                 | path to the data directory, do not change this if you're using docker              |
-| HBOX_STORAGE_SQLITE_URL              | /data/homebox.db?_fk=1 | sqlite database url, if you're using docker do not change this                     |
-| HBOX_LOG_LEVEL                       | info                   | log level to use, can be one of: trace, debug, info, warn, error, critical         |
-| HBOX_LOG_FORMAT                      | text                   | log format to use, can be one of: text, json                                       |
-| HBOX_MAILER_HOST                     |                        | email host to use, if not set no email provider will be used                       |
-| HBOX_MAILER_PORT                     | 587                    | email port to use                                                                  |
-| HBOX_MAILER_USERNAME                 |                        | email user to use                                                                  |
-| HBOX_MAILER_PASSWORD                 |                        | email password to use                                                              |
-| HBOX_MAILER_FROM                     |                        | email from address to use                                                          |
-| HBOX_SWAGGER_HOST                    | 7745                   | swagger host to use, if not set swagger will be disabled                           |
-| HBOX_SWAGGER_SCHEMA                  | http                   | swagger schema to use, can be one of: http, https                                  |
+| Variable                             | Default                | Description                                                                                         |
+| ------------------------------------ | ---------------------- | --------------------------------------------------------------------------------------------------- |
+| HBOX_MODE                            | production             | application mode used for runtime behavior  can be one of: development, production                  |
+| HBOX_WEB_PORT                        | 7745                   | port to run the web server on, if you're using docker do not change this                            |
+| HBOX_WEB_HOST                        |                        | host to run the web server on, if you're using docker do not change this                            |
+| HBOX_OPTIONS_ALLOW_REGISTRATION      | true                   | allow users to register themselves                                                                  |
+| HBOX_OPTIONS_AUTO_INCREMENT_ASSET_ID | true                   | auto increments the asset_id field for new items                                                    |
+| HBOX_OPTIONS_CURRENCY_CONFIG         |                        | json configuration file containing additional currencies                                            |
+| HBOX_WEB_MAX_UPLOAD_SIZE             | 10                     | maximum file upload size supported in MB                                                            |
+| HBOX_WEB_READ_TIMEOUT                | 10                     | Read timeout of HTTP sever                                                                          |
+| HBOX_WEB_WRITE_TIMEOUT               | 10                     | Write timeout of HTTP server                                                                        |
+| HBOX_WEB_IDLE_TIMEOUT                | 30                     | Idle timeout of HTTP server                                                                         |
+| HBOX_AUTH_FORWARD_AUTH_HEADER        | Remote-Email           | Header used to identify user, when forward auth proxy is used                                       |
+| HBOX_AUTH_FORWARD_AUTH_ALLOWED_IPS   |                        | Coma separated list of IP CIDRs, allowed to use forward auth - empty list (default), means deny all |
+| HBOX_AUTH_FORWARD_AUTH_AUTO_REGISTER | false                  | If true, non-existing user forwarded by auth proxy will be automatically registered                 |
+| HBOX_STORAGE_DATA                    | /data/                 | path to the data directory, do not change this if you're using docker                               |
+| HBOX_STORAGE_SQLITE_URL              | /data/homebox.db?_fk=1 | sqlite database url, if you're using docker do not change this                                      |
+| HBOX_LOG_LEVEL                       | info                   | log level to use, can be one of: trace, debug, info, warn, error, critical                          |
+| HBOX_LOG_FORMAT                      | text                   | log format to use, can be one of: text, json                                                        |
+| HBOX_MAILER_HOST                     |                        | email host to use, if not set no email provider will be used                                        |
+| HBOX_MAILER_PORT                     | 587                    | email port to use                                                                                   |
+| HBOX_MAILER_USERNAME                 |                        | email user to use                                                                                   |
+| HBOX_MAILER_PASSWORD                 |                        | email password to use                                                                               |
+| HBOX_MAILER_FROM                     |                        | email from address to use                                                                           |
+| HBOX_SWAGGER_HOST                    | 7745                   | swagger host to use, if not set swagger will be disabled                                            |
+| HBOX_SWAGGER_SCHEMA                  | http                   | swagger schema to use, can be one of: http, https                                                   |
 
 !!! tip "CLI Arguments"
       If you're deploying without docker you can use command line arguments to configure the application. Run `homebox --help` for more information.
@@ -85,26 +88,32 @@ volumes:
       Usage: api [options] [arguments]
 
       OPTIONS
-        --mode/$HBOX_MODE                                                        <string>  (default: development)
-        --web-port/$HBOX_WEB_PORT                                                <string>  (default: 7745)
+        --mode/$HBOX_MODE                                                        <string>    (default: development)
+        --web-port/$HBOX_WEB_PORT                                                <string>    (default: 7745)
         --web-host/$HBOX_WEB_HOST                                                <string>
-        --web-max-upload-size/$HBOX_WEB_MAX_UPLOAD_SIZE                          <int>     (default: 10)
-        --storage-data/$HBOX_STORAGE_DATA                                        <string>  (default: ./.data)
-        --storage-sqlite-url/$HBOX_STORAGE_SQLITE_URL                            <string>  (default: ./.data/homebox.db?_fk=1)
-        --log-level/$HBOX_LOG_LEVEL                                              <string>  (default: info)
-        --log-format/$HBOX_LOG_FORMAT                                            <string>  (default: text)
+        --web-max-upload-size/$HBOX_WEB_MAX_UPLOAD_SIZE                          <int>       (default: 10)
+        --web-read-timeout/$HBOX_WEB_READ_TIMEOUT                                <duration>  (default: 10s)
+        --web-write-timeout/$HBOX_WEB_WRITE_TIMEOUT                              <duration>  (default: 10s)
+        --web-idle-timeout/$HBOX_WEB_IDLE_TIMEOUT                                <duration>  (default: 30s)
+        --auth-forward-auth-header/$HBOX_AUTH_FORWARD_AUTH_HEADER                <string>    (default: Remote-Email)
+        --auth-forward-auth-allowed-ips/$HBOX_AUTH_FORWARD_AUTH_ALLOWED_IPS      <string>
+        --auth-forward-auth-auto-register/$HBOX_AUTH_FORWARD_AUTH_AUTO_REGISTER  <bool>      (default: false)
+        --storage-data/$HBOX_STORAGE_DATA                                        <string>    (default: ./.data)
+        --storage-sqlite-url/$HBOX_STORAGE_SQLITE_URL                            <string>    (default: ./.data/homebox.db?_fk=1)
+        --log-level/$HBOX_LOG_LEVEL                                              <string>    (default: info)
+        --log-format/$HBOX_LOG_FORMAT                                            <string>    (default: text)
         --mailer-host/$HBOX_MAILER_HOST                                          <string>
         --mailer-port/$HBOX_MAILER_PORT                                          <int>
         --mailer-username/$HBOX_MAILER_USERNAME                                  <string>
         --mailer-password/$HBOX_MAILER_PASSWORD                                  <string>
         --mailer-from/$HBOX_MAILER_FROM                                          <string>
-        --swagger-host/$HBOX_SWAGGER_HOST                                        <string>  (default: localhost:7745)
-        --swagger-scheme/$HBOX_SWAGGER_SCHEME                                    <string>  (default: http)
+        --swagger-host/$HBOX_SWAGGER_HOST                                        <string>    (default: localhost:7745)
+        --swagger-scheme/$HBOX_SWAGGER_SCHEME                                    <string>    (default: http)
         --demo/$HBOX_DEMO                                                        <bool>
-        --debug-enabled/$HBOX_DEBUG_ENABLED                                      <bool>    (default: false)
-        --debug-port/$HBOX_DEBUG_PORT                                            <string>  (default: 4000)
-        --options-allow-registration/$HBOX_OPTIONS_ALLOW_REGISTRATION            <bool>    (default: true)
-        --options-auto-increment-asset-id/$HBOX_OPTIONS_AUTO_INCREMENT_ASSET_ID  <bool>    (default: true)
+        --debug-enabled/$HBOX_DEBUG_ENABLED                                      <bool>      (default: false)
+        --debug-port/$HBOX_DEBUG_PORT                                            <string>    (default: 4000)
+        --options-allow-registration/$HBOX_OPTIONS_ALLOW_REGISTRATION            <bool>      (default: true)
+        --options-auto-increment-asset-id/$HBOX_OPTIONS_AUTO_INCREMENT_ASSET_ID  <bool>      (default: true)
         --options-currency-config/$HBOX_OPTIONS_CURRENCY_CONFIG                  <string>
         --help/-h
         display this help message

--- a/frontend/composables/use-auth-context.ts
+++ b/frontend/composables/use-auth-context.ts
@@ -84,8 +84,8 @@ class AuthContext implements IAuthContext {
     console.log("Session invalidated");
   }
 
-  async login(api: PublicApi, email: string, password: string, stayLoggedIn: boolean) {
-    const r = await api.login(email, password, stayLoggedIn);
+  async login(api: PublicApi, email: string, password: string, stayLoggedIn: boolean, provider = "local") {
+    const r = await api.login(email, password, stayLoggedIn, provider);
 
     if (!r.error) {
       const expiresAt = new Date(r.data.expiresAt);

--- a/frontend/lib/api/public.ts
+++ b/frontend/lib/api/public.ts
@@ -13,9 +13,9 @@ export class PublicApi extends BaseAPI {
     return this.http.get<APISummary>({ url: route("/status") });
   }
 
-  public login(username: string, password: string, stayLoggedIn = false) {
+  public login(username: string, password: string, stayLoggedIn = false, provider = "local") {
     return this.http.post<LoginForm, TokenResponse>({
-      url: route("/users/login"),
+      url: route("/users/login?provider=" + provider),
       body: {
         username,
         password,

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -45,6 +45,9 @@
       email.value = "demo@example.com";
       loginPassword.value = "demo";
     }
+    if (status?.forwardAuthAvailable) {
+      loginViaForwardAuth()
+    }
   });
 
   const route = useRoute();
@@ -118,6 +121,16 @@
 
     navigateTo("/home");
     loading.value = false;
+  }
+
+  async function loginViaForwardAuth() {
+    const { error } = await ctx.login(api, email.value, loginPassword.value, remember.value, "forwardauth");
+
+    if (error) {
+      return;
+    }
+
+    navigateTo("/home");
   }
 
   const [registerForm, toggleLogin] = useToggle();


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR introduces a new authentication provider, called "ForwardAuth". It's written with forward-authentication supporting reverse proxies (like nginx or traefik) and accomodanting authentication apps (like authelia, authentik and probably many more).

With this changes, if homebox is configured in one of Fw-Auth setups, it will automatically sign in (and register, depending on configuration) user forwarded by initial authentication backend, thus removing necessity of logging in twice.

This is done by special header (also configurable, by default `Remote-Email`) which tells homebox, that authentication was already be done, and it can trust that given email is already valid. Of course, a malicious user, my try to send this user, by themself trying to impersonate the real one - but in properly configured fw-auth setups it shouldn't be possible. Anyway, to avoid any mistakes, there is another configurable field, defining list of IPs which are allowed to be source of fw-auth traffic. By default it's empty, meaning every source is blacklisted - thus feature is disabled. This also protects installations which doesn't need this feature, to not accidentally expose themselves.

## Which issue(s) this PR fixes:

Implements #270 

## Testing

I deployed updated code to my cluster, and tested everything with authelia. 

## Release Notes

```release-note
- Support for forward-authentication applications like authelia.
```