### PR TITLE
Add Docker Healthcheck to both containers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ HEALTHCHECK --interval=30s \
             --timeout=5s \
             --start-period=5s \
             --retries=3 \
-            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7745" ]
+            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7745/api/v1/status" ]
 WORKDIR /app
 VOLUME [ "/data" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,11 @@ RUN chmod +x /app/api
 LABEL Name=homebox Version=0.0.1
 LABEL org.opencontainers.image.source="https://github.com/hay-kot/homebox"
 EXPOSE 7745
+HEALTHCHECK --interval=30s \
+            --timeout=5s \
+            --start-period=5s \
+            --retries=3 \
+            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7745" ]
 WORKDIR /app
 VOLUME [ "/data" ]
 

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -13,6 +13,7 @@ FROM golang:alpine AS builder
 ARG BUILD_TIME
 ARG COMMIT
 ARG VERSION
+ARG BUSYBOX_VERSION=1.31.0-i686-uclibc
 RUN apk update && \
     apk upgrade && \
     apk add --update git build-base gcc g++
@@ -30,6 +31,14 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     # create a directory so that we can copy it in the next stage
     mkdir /data
 
+# Downloading Wget
+ADD https://busybox.net/downloads/binaries/$BUSYBOX_VERSION/busybox_WGET /wget
+RUN chmod a+x /wget
+
+FROM gcr.io/distroless/java
+
+COPY --from=builder /wget /usr/bin/wget
+
 # Production Stage
 FROM gcr.io/distroless/static
 
@@ -41,10 +50,16 @@ ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_fk=1
 # change the ownership to the low-privileged user
 COPY --from=builder --chown=nonroot /go/bin/api /app
 COPY --from=builder --chown=nonroot /data /data
+COPY --from=builder --chown=nonroot /wget /usr/bin/wget
 
 LABEL Name=homebox Version=0.0.1
 LABEL org.opencontainers.image.source="https://github.com/hay-kot/homebox"
 EXPOSE 7745
+HEALTHCHECK --interval=30s \
+            --timeout=5s \
+            --start-period=5s \
+            --retries=3 \
+            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7745" ]
 VOLUME [ "/data" ]
 
 # Drop root and run as low-privileged user

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -59,7 +59,7 @@ HEALTHCHECK --interval=30s \
             --timeout=5s \
             --start-period=5s \
             --retries=3 \
-            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7745" ]
+            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7745/api/v1/status" ]
 VOLUME [ "/data" ]
 
 # Drop root and run as low-privileged user


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR introduced Docker Healthcheck to normal and rootless containers. It is Based on https://github.com/GoogleContainerTools/distroless/issues/183#issuecomment-823181507

## Which issue(s) this PR fixes:

Fixes #890

## Special notes for your reviewer:

You asked for PR :smile: 

## Testing

Container was build and after 30 Seconds marked as `healthy`. Also GET request to the `/` can be seen in the logs.

## Release Notes

```release-note
- Add `wget` to `rootless` container.
- Introduced Healthcheck to containers.
```