### PR TITLE
remove deprecated version specifier for Docker v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   homebox:
     image: homebox

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -27,8 +27,6 @@ $ docker run -d \
 ## Docker-Compose
 
 ```yaml
-version: "3.4"
-
 services:
   homebox:
     image: ghcr.io/hay-kot/homebox:latest


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- documentation
- cleanup

## What this PR does / why we need it:

The Docker Compose v2 version "version: x.x" key/value pair is obsolete according to Docker Compose's v2 spec:

https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements

Updated reference in both the documentation and the main docker-compose.yml file.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Fixes #901

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Release Notes

<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
- Removes "version: x.x" key/value pair from Docker Compose file/docs
```