### PR TITLE
Change maintenance dialog field order

### DIFF
--- a/backend/internal/core/currencies/currencies.json
+++ b/backend/internal/core/currencies/currencies.json
@@ -625,9 +625,9 @@
   },
   {
     "code": "NOK",
-    "local": "Norge",
+    "local": "Norway",
     "symbol": "kr",
-    "name": "Norske kroner"
+    "name": "Norwegian Krone"
   },
   {
     "code": "UAH",

--- a/backend/internal/core/currencies/currencies.json
+++ b/backend/internal/core/currencies/currencies.json
@@ -624,6 +624,12 @@
     "name": "Nicaraguan Córdoba"
   },
   {
+    "code": "NOK",
+    "local": "Norge",
+    "symbol": "kr",
+    "name": "Norske kroner"
+  },
+  {
     "code": "UAH",
     "local": "Ukraine",
     "symbol": "₴",

--- a/frontend/pages/item/[id]/index/maintenance.vue
+++ b/frontend/pages/item/[id]/index/maintenance.vue
@@ -184,10 +184,10 @@
       </template>
       <form @submit.prevent="dispatchFormSubmit">
         <FormTextField v-model="entry.name" autofocus label="Entry Name" />
-        <DatePicker v-model="entry.completedDate" label="Completed Date" />
         <DatePicker v-model="entry.scheduledDate" label="Scheduled Date" />
-        <FormTextArea v-model="entry.description" label="Notes" />
+        <DatePicker v-model="entry.completedDate" label="Completed Date" />
         <FormTextField v-model="entry.cost" autofocus label="Cost" />
+        <FormTextArea v-model="entry.description" label="Notes" />
         <div class="py-2 flex justify-end">
           <BaseButton type="submit" class="ml-2 mt-2">
             <template #icon>


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- enhancement

## What this PR does / why we need it:


<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

This PR changes the order of the fields in the maintenance dialog. The original order was 

`title/completed/scheduled/notes/costs`. 

This changed to `title/scheduled/completed/costs/notes`.
When using the maintenance dialog the scheduled information was always earlier available than when the maintenance was completed. Therefore that field coming right after the title seems to be more sensible.

Something similar was/is true for the order of costs and notes. In my use cases I have more often a value for `cost` than actually for `notes`, which is why it seems more meaningful to have the field coming before `notes`. Also `notes` is the bigger field, which layout wise makes it slightly more sensible to put to the end. That way `Costs` does not get completely out of focus.

## Which issue(s) this PR fixes:

None

## Testing

* created a docker image, fired it up and verified the position of the fields has changed accordingly.

<!--
  Describe how you tested this change.
-->

## Release Notes


<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.
  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note
Changing the order of the fields in the maintenance dialog of an asset.
```